### PR TITLE
Kontakte abrufen 37

### DIFF
--- a/src/main/java/com/spaghetticodegang/trylater/contact/ContactController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/contact/ContactController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
  * REST controller providing endpoints for managing user contacts.
  */
@@ -59,5 +61,28 @@ public class ContactController {
     public ResponseEntity<Void> deleteContact(@AuthenticationPrincipal User me, @PathVariable("id") Long contactId) {
         contactService.deleteContact(me, contactId);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Returns a contact or contact request by delegating the request to the service layer.
+     *
+     * @param me        the currently authenticated user
+     * @param contactId the ID of the contact whose is requested
+     * @return the created contact as a response DTO
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ContactResponseDto> getContactById(@AuthenticationPrincipal User me, @PathVariable("id") Long contactId) {
+        return ResponseEntity.ok(contactService.getContact(me, contactId));
+    }
+
+    /**
+     * Returns all contact or contact request for a user by delegating the request to the service layer.
+     *
+     * @param me the currently authenticated user
+     * @return the created contact as a response DTO
+     */
+    @GetMapping
+    public ResponseEntity<List<ContactResponseDto>> getAllContacts(@AuthenticationPrincipal User me, @RequestParam(name = "contactStatus", required = false) ContactStatus contactStatus) {
+        return ResponseEntity.ok(contactService.getAllContacts(me, contactStatus));
     }
 }

--- a/src/main/java/com/spaghetticodegang/trylater/contact/ContactController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/contact/ContactController.java
@@ -83,6 +83,6 @@ public class ContactController {
      */
     @GetMapping
     public ResponseEntity<List<ContactResponseDto>> getAllContacts(@AuthenticationPrincipal User me, @RequestParam(name = "contactStatus", required = false) ContactStatus contactStatus) {
-        return ResponseEntity.ok(contactService.getAllContacts(me, contactStatus));
+        return ResponseEntity.ok(contactService.getAllContactsForUser(me, contactStatus));
     }
 }

--- a/src/main/java/com/spaghetticodegang/trylater/contact/ContactRepository.java
+++ b/src/main/java/com/spaghetticodegang/trylater/contact/ContactRepository.java
@@ -3,6 +3,8 @@ package com.spaghetticodegang.trylater.contact;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 /**
  * Repository interface for accessing and managing contact entities in the database.
  */
@@ -17,12 +19,34 @@ public interface ContactRepository extends JpaRepository<Contact, Long> {
      * @return true if a contact already exists between the two users, false otherwise
      */
     @Query("""
-    SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END
-    FROM Contact c
-    WHERE (c.requester.id = :userId1 AND c.receiver.id = :userId2)
-       OR (c.requester.id = :userId2 AND c.receiver.id = :userId1)
-    """)
+            SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END
+            FROM Contact c
+            WHERE (c.requester.id = :userId1 AND c.receiver.id = :userId2)
+               OR (c.requester.id = :userId2 AND c.receiver.id = :userId1)
+            """)
     boolean existsByUserIds(Long userId1, Long userId2);
 
+    /**
+     * Finds all contacts for a given requesterId or receiverId.
+     *
+     * @param userId the ID of the requester
+     * @return a list of {@link Contact} entities.
+     */
+    @Query("""
+            SELECT c FROM Contact c WHERE c.requester.id = :userId OR c.receiver.id = :userId
+            """)
+    List<Contact> findByUserId(Long userId);
 
+    /**
+     * Finds all contacts for a given requesterId or receiverId.
+     * Filters the contacts according to the given status.
+     *
+     * @param userId        the ID of the requester or receiver
+     * @param contactStatus the contact status
+     * @return a list of {@link Contact} entities.
+     */
+    @Query("""
+            SELECT c FROM Contact c WHERE (c.requester.id = :userId OR c.receiver.id = :userId) AND c.contactStatus = :contactStatus
+            """)
+    List<Contact> findByUserIdAndContactStatus(Long userId, ContactStatus contactStatus);
 }

--- a/src/main/java/com/spaghetticodegang/trylater/contact/ContactRepository.java
+++ b/src/main/java/com/spaghetticodegang/trylater/contact/ContactRepository.java
@@ -27,13 +27,13 @@ public interface ContactRepository extends JpaRepository<Contact, Long> {
     boolean existsByUserIds(Long userId1, Long userId2);
 
     /**
-     * Finds all contacts for a given requesterId or receiverId.
+     * Finds all contacts excepted BLOCKED for a given requesterId or receiverId.
      *
      * @param userId the ID of the requester
      * @return a list of {@link Contact} entities.
      */
     @Query("""
-            SELECT c FROM Contact c WHERE c.requester.id = :userId OR c.receiver.id = :userId
+            SELECT c FROM Contact c WHERE (c.requester.id = :userId OR c.receiver.id = :userId) AND c.contactStatus <> 'BLOCKED'
             """)
     List<Contact> findByUserId(Long userId);
 
@@ -46,7 +46,7 @@ public interface ContactRepository extends JpaRepository<Contact, Long> {
      * @return a list of {@link Contact} entities.
      */
     @Query("""
-            SELECT c FROM Contact c WHERE (c.requester.id = :userId OR c.receiver.id = :userId) AND c.contactStatus = :contactStatus
+            SELECT c FROM Contact c WHERE (c.requester.id = :userId OR c.receiver.id = :userId) AND c.contactStatus = :contactStatus AND c.contactStatus <> 'BLOCKED'
             """)
     List<Contact> findByUserIdAndContactStatus(Long userId, ContactStatus contactStatus);
 }

--- a/src/main/java/com/spaghetticodegang/trylater/contact/ContactService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/contact/ContactService.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/com/spaghetticodegang/trylater/contact/ContactService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/contact/ContactService.java
@@ -181,7 +181,7 @@ public class ContactService {
      * @param me the authenticated user
      * @return a list of response DTO representing the contacts optional filters
      */
-    public List<ContactResponseDto> getAllContacts(User me, ContactStatus contactStatus) {
+    public List<ContactResponseDto> getAllContactsForUser(User me, ContactStatus contactStatus) {
 
         List<Contact> contacts = findContactsByUserId(me.getId(), contactStatus);
 
@@ -198,7 +198,7 @@ public class ContactService {
      * @return a list of the contact entities
      */
     public List<Contact> findContactsByUserId(Long userId, ContactStatus contactStatus) {
-        if (contactStatus != null && !EnumSet.of(ContactStatus.ACCEPTED, ContactStatus.PENDING).contains(contactStatus)) {
+        if (contactStatus != null) {
             return contactRepository.findByUserIdAndContactStatus(userId, contactStatus);
         }
         return contactRepository.findByUserId(userId);

--- a/src/main/java/com/spaghetticodegang/trylater/contact/ContactService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/contact/ContactService.java
@@ -12,8 +12,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Service layer for handling business logic related to user contacts.
@@ -55,7 +58,7 @@ public class ContactService {
      * Creates a new contact request between the authenticated user and the target user.
      * Performs validation to prevent duplicate or self-referential contacts.
      *
-     * @param me the authenticated user initiating the request
+     * @param me      the authenticated user initiating the request
      * @param request the contact request containing the target user's ID
      * @return a response DTO representing the newly created contact
      * @throws ValidationException if the target is the same as the requester
@@ -89,8 +92,8 @@ public class ContactService {
     /**
      * Performs validation and updates the contact's status, including setting the acceptance date if applicable.
      *
-     * @param me the currently authenticated user
-     * @param contactId the ID of the contact whose status is to be updated
+     * @param me                      the currently authenticated user
+     * @param contactId               the ID of the contact whose status is to be updated
      * @param contactStatusRequestDto the DTO containing the new contact status
      * @return a response DTO representing the updated contact
      * @throws ValidationException if the status change is invalid
@@ -125,7 +128,7 @@ public class ContactService {
      * Creates a response DTO from a {@link Contact} entity.
      * Determines which user is the contact partner (not the authenticated user).
      *
-     * @param me the authenticated user
+     * @param me      the authenticated user
      * @param contact the contact entity
      * @return a response DTO representing the contact
      */
@@ -143,7 +146,7 @@ public class ContactService {
      * Deletes a {@link Contact} entity.
      * Determines which user is the contact partner (not the authenticated user).
      *
-     * @param me the authenticated user
+     * @param me        the authenticated user
      * @param contactId the contact id
      */
     public void deleteContact(User me, Long contactId) {
@@ -152,5 +155,52 @@ public class ContactService {
             throw new ValidationException(Map.of("contact", messageUtil.get("contact.error.user.not.found")));
         }
         contactRepository.deleteById(contactId);
+    }
+
+    /**
+     * Searches the contact repository for a given id.
+     *
+     * @param me        the authenticated user
+     * @param contactId the contact id
+     * @return a response DTO representing the contact
+     * @throws ValidationException if the user is neither the requester nor receiver of the contact
+     */
+    public ContactResponseDto getContact(User me, Long contactId) {
+        final Contact contact = findContactById(contactId);
+
+        if (!Objects.equals(contact.getRequester().getId(), me.getId()) && !Objects.equals(contact.getReceiver().getId(), me.getId())) {
+            throw new ValidationException(Map.of("contact", messageUtil.get("contact.error.user.not.found")));
+        }
+
+        return createContactResponseDto(me, contact);
+    }
+
+    /**
+     * Searches the contact repository for all contact of the user.
+     *
+     * @param me the authenticated user
+     * @return a list of response DTO representing the contacts optional filters
+     */
+    public List<ContactResponseDto> getAllContacts(User me, ContactStatus contactStatus) {
+
+        List<Contact> contacts = findContactsByUserId(me.getId(), contactStatus);
+
+        return contacts.stream()
+                .map(contact -> createContactResponseDto(me, contact))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Finds all contacts by their user.
+     *
+     * @param userId the ID of the user
+     * @param contactStatus the status of the contact
+     * @return a list of the contact entities
+     */
+    public List<Contact> findContactsByUserId(Long userId, ContactStatus contactStatus) {
+        if (contactStatus != null && !EnumSet.of(ContactStatus.ACCEPTED, ContactStatus.PENDING).contains(contactStatus)) {
+            return contactRepository.findByUserIdAndContactStatus(userId, contactStatus);
+        }
+        return contactRepository.findByUserId(userId);
     }
 }

--- a/src/test/java/com/spaghetticodegang/trylater/contact/ContactControllerTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/contact/ContactControllerTest.java
@@ -135,7 +135,7 @@ class ContactControllerTest {
                 createContactResponse(ContactStatus.PENDING)
         );
 
-        when(contactService.getAllContacts(any(User.class), any()))
+        when(contactService.getAllContactsForUser(any(User.class), any()))
                 .thenReturn(contactList);
 
         mockMvc.perform(get("/api/contact")
@@ -150,7 +150,7 @@ class ContactControllerTest {
     void shouldReturn200_whenGetAllContactsWithValidStatus() throws Exception {
         List<ContactResponseDto> filtered = List.of(createContactResponse(ContactStatus.PENDING));
 
-        when(contactService.getAllContacts(any(User.class), any(ContactStatus.class)))
+        when(contactService.getAllContactsForUser(any(User.class), any(ContactStatus.class)))
                 .thenReturn(filtered);
 
         mockMvc.perform(get("/api/contact")

--- a/src/test/java/com/spaghetticodegang/trylater/contact/ContactRepositoryTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/contact/ContactRepositoryTest.java
@@ -75,4 +75,51 @@ class ContactRepositoryTest {
         boolean exists = contactRepository.existsByUserIds(requester.getId(), receiver.getId());
         assertThat(exists).isFalse();
     }
+
+    @Test
+    void shouldReturnAllContactsByUserId() {
+        Contact contact1 = contactRepository.save(Contact.builder()
+                .requester(requester)
+                .receiver(receiver)
+                .contactStatus(ContactStatus.PENDING)
+                .requestDate(LocalDateTime.now())
+                .build());
+
+        Contact contact2 = contactRepository.save(Contact.builder()
+                .requester(receiver)
+                .receiver(requester)
+                .contactStatus(ContactStatus.ACCEPTED)
+                .requestDate(LocalDateTime.now())
+                .build());
+
+        var result = contactRepository.findByUserId(requester.getId());
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(Contact::getContactStatus)
+                .containsExactlyInAnyOrder(ContactStatus.PENDING, ContactStatus.ACCEPTED);
+    }
+
+    @Test
+    void shouldReturnFilteredContactsByUserIdAndStatus() {
+        contactRepository.save(Contact.builder()
+                .requester(requester)
+                .receiver(receiver)
+                .contactStatus(ContactStatus.PENDING)
+                .requestDate(LocalDateTime.now())
+                .build());
+
+        contactRepository.save(Contact.builder()
+                .requester(receiver)
+                .receiver(requester)
+                .contactStatus(ContactStatus.ACCEPTED)
+                .requestDate(LocalDateTime.now())
+                .build());
+
+        var result = contactRepository.findByUserIdAndContactStatus(requester.getId(), ContactStatus.ACCEPTED);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getContactStatus()).isEqualTo(ContactStatus.ACCEPTED);
+        assertThat(result.getFirst().getRequester()).isEqualTo(receiver);
+    }
+
 }

--- a/src/test/java/com/spaghetticodegang/trylater/contact/ContactServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/contact/ContactServiceTest.java
@@ -15,8 +15,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -193,4 +195,96 @@ class ContactServiceTest {
         assertEquals("Du bist diesem Kontakt nicht zugeordnet.", ex.getErrors().get("contact"));
         verify(contactRepository, never()).deleteById(anyLong());
     }
+
+    @Test
+    void shouldReturnContactById_whenUserIsInvolved() {
+        User me = createUser(1L);
+        User other = createUser(2L);
+        Contact contact = createContact(me, other);
+        UserResponseDto partnerDto = createUserResponse(other);
+
+        when(contactRepository.findById(99L)).thenReturn(Optional.of(contact));
+        when(userService.createUserResponseDto(other)).thenReturn(partnerDto);
+
+        ContactResponseDto result = contactService.getContact(me, 99L);
+
+        assertNotNull(result);
+        assertEquals(99L, result.getContactId());
+        assertEquals(ContactStatus.PENDING, result.getContactStatus());
+        assertEquals(partnerDto, result.getContactPartner());
+    }
+
+    @Test
+    void shouldThrowValidationException_whenUserNotPartOfContact() {
+        User me = createUser(1L);
+        User unrelated = createUser(3L);
+        User other = createUser(2L);
+        Contact contact = createContact(unrelated, other);
+
+        when(contactRepository.findById(99L)).thenReturn(Optional.of(contact));
+        when(messageUtil.get("contact.error.user.not.found")).thenReturn("Du bist diesem Kontakt nicht zugeordnet.");
+
+        ValidationException ex = assertThrows(ValidationException.class, () -> {
+            contactService.getContact(me, 99L);
+        });
+
+        assertTrue(ex.getErrors().containsKey("contact"));
+        assertEquals("Du bist diesem Kontakt nicht zugeordnet.", ex.getErrors().get("contact"));
+    }
+
+    @Test
+    void shouldReturnAllContactsWithoutFilter() {
+        User me = createUser(1L);
+        Contact contact1 = createContact(me, createUser(2L));
+        Contact contact2 = createContact(me, createUser(3L));
+        UserResponseDto dto1 = createUserResponse(contact1.getReceiver());
+        UserResponseDto dto2 = createUserResponse(contact2.getReceiver());
+
+        when(contactRepository.findByUserId(1L)).thenReturn(List.of(contact1, contact2));
+        when(userService.createUserResponseDto(contact1.getReceiver())).thenReturn(dto1);
+        when(userService.createUserResponseDto(contact2.getReceiver())).thenReturn(dto2);
+
+        List<ContactResponseDto> result = contactService.getAllContacts(me, null);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(ContactResponseDto::getContactStatus)
+                .containsOnly(ContactStatus.PENDING);
+    }
+
+    @Test
+    void shouldReturnFilteredContacts_whenValidStatusIsGiven() {
+        User me = createUser(1L);
+        User other = createUser(2L);
+        Contact contact = createContact(me, other);
+        UserResponseDto contactPartnerDto = createUserResponse(other);
+
+        when(contactRepository.findByUserIdAndContactStatus(1L, ContactStatus.PENDING))
+                .thenReturn(List.of(contact));
+
+        when(userService.createUserResponseDto(other)).thenReturn(contactPartnerDto);
+
+        List<ContactResponseDto> result = contactService.getAllContacts(me, ContactStatus.PENDING);
+
+        assertEquals(1, result.size());
+        assertEquals(99L, result.getFirst().getContactId());
+        assertEquals(ContactStatus.PENDING, result.getFirst().getContactStatus());
+        assertEquals(contactPartnerDto, result.getFirst().getContactPartner());
+    }
+
+
+    @Test
+    void shouldCallRepositoryWithUnfilteredQuery_whenStatusIsNotAcceptedOrPending() {
+        User me = createUser(1L);
+        Contact contact = createContact(me, createUser(2L));
+        UserResponseDto dto = createUserResponse(contact.getReceiver());
+
+        when(contactRepository.findByUserId(1L)).thenReturn(List.of(contact));
+        when(userService.createUserResponseDto(contact.getReceiver())).thenReturn(dto);
+
+        List<ContactResponseDto> result = contactService.getAllContacts(me, ContactStatus.BLOCKED);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getContactStatus()).isEqualTo(ContactStatus.PENDING);
+    }
+
 }


### PR DESCRIPTION
Kontakte mit Status "BLOCKED" werden bei request für alle vorhanden Kontakte des Users nicht angezeigt
Wird ein Kontakt explizit mittels der ID abgefragt, werden auch BLOCKED angezeigt
Sollten auch so alle BLOCKED angezeigt werden, kann es einfach im Code des ContactRespositorys geändert werden