### PR TITLE
Benutzerdaten aendern 47

### DIFF
--- a/src/main/java/com/spaghetticodegang/trylater/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/spaghetticodegang/trylater/shared/exception/GlobalExceptionHandler.java
@@ -119,6 +119,19 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Handles authentication failures caused by incorrect password.
+     *
+     * @param ex the exception thrown when the password is not correct
+     * @return a 400 Bad Request response with a user-friendly error message
+     */
+    @ExceptionHandler(PasswordErrorException.class)
+    public ResponseEntity<Object> handleRecommendationNotFound(PasswordErrorException ex) {
+        return ResponseEntity.badRequest().body(Map.of(
+                "message", messageUtil.get(ex.getMessage())
+        ));
+    }
+
+    /**
      * Handles authentication failures caused by non-existent recommendation assignment.
      *
      * @param ex the exception thrown when the recommendation assignment is not found

--- a/src/main/java/com/spaghetticodegang/trylater/shared/exception/PasswordErrorException.java
+++ b/src/main/java/com/spaghetticodegang/trylater/shared/exception/PasswordErrorException.java
@@ -1,0 +1,14 @@
+package com.spaghetticodegang.trylater.shared.exception;
+
+/**
+ * Thrown when the password is missing or incorrect.
+ */
+public class PasswordErrorException extends RuntimeException {
+
+    /**
+     * Constructs a new {@code MissingPasswordException} for the given user.
+     */
+    public PasswordErrorException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserController.java
@@ -57,6 +57,13 @@ public class UserController {
         return ResponseEntity.ok(userResponseDto);
     }
 
+    /**
+     * Handles the user profile update request by delegating to the service layer.
+     *
+     * @param me the currently authenticated user (injected by Spring Security)
+     * @param userMeUpdateDto the updated data provided by the user
+     * @return the updated user's public information
+     */
     @PatchMapping("/me")
     public ResponseEntity<UserMeResponseDto> updateUserProfile(@AuthenticationPrincipal User me, @RequestBody @Valid UserMeUpdateDto userMeUpdateDto) {
         UserMeResponseDto userMeResponseDto = userService.updateUserProfile(me, userMeUpdateDto);

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserController.java
@@ -2,6 +2,7 @@ package com.spaghetticodegang.trylater.user;
 
 import com.spaghetticodegang.trylater.user.dto.UserMeResponseDto;
 import com.spaghetticodegang.trylater.user.dto.UserMeRegistrationDto;
+import com.spaghetticodegang.trylater.user.dto.UserMeUpdateDto;
 import com.spaghetticodegang.trylater.user.dto.UserResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -54,5 +55,11 @@ public class UserController {
     public ResponseEntity<UserResponseDto> searchUser(@RequestParam String user) {
         UserResponseDto userResponseDto = userService.searchUser(user);
         return ResponseEntity.ok(userResponseDto);
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<UserMeResponseDto> updateUserProfile(@AuthenticationPrincipal User me, @RequestBody @Valid UserMeUpdateDto userMeUpdateDto) {
+        UserMeResponseDto userMeResponseDto = userService.updateUserProfile(me, userMeUpdateDto);
+        return ResponseEntity.ok(userMeResponseDto);
     }
 }

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -152,7 +152,7 @@ public class UserService implements UserDetailsService {
                 throw new PasswordErrorException("update.password.notblank");
             }
             if (!passwordEncoder.matches(userMeUpdateDto.getCurrentPassword(), me.getPassword())) {
-                throw new UsernameNotFoundException("auth.invalid.credentials");
+                throw new PasswordErrorException("auth.invalid.password");
             }
         }
 

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -6,7 +6,6 @@ import com.spaghetticodegang.trylater.user.dto.UserMeRegistrationDto;
 import com.spaghetticodegang.trylater.user.dto.UserMeResponseDto;
 import com.spaghetticodegang.trylater.user.dto.UserMeUpdateDto;
 import com.spaghetticodegang.trylater.user.dto.UserResponseDto;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -138,6 +138,16 @@ public class UserService implements UserDetailsService {
         return createUserResponseDto(user);
     }
 
+    /**
+     * Updates the user profile with the new given entries.
+     * Authentication required for username, email and new password.
+     *
+     * @param me user entity that profile should be updated
+     * @param userMeUpdateDto request dto with the new data
+     * @return a full response DTO for the currently authenticated user
+     * @throws PasswordErrorException if password input for authentication is incorrect
+     * @throws ValidationException if username or email already exists
+     */
     public UserMeResponseDto updateUserProfile(User me, UserMeUpdateDto userMeUpdateDto) {
         final Map<String, String> errors = new HashMap<>();
 

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -148,10 +148,10 @@ public class UserService implements UserDetailsService {
 
         if (isSensitiveChange) {
             if (userMeUpdateDto.getCurrentPassword() == null) {
-                errors.put("password", messageUtil.get("user.password.notblank"));
+                errors.put("user", messageUtil.get("user.password.notblank"));
             }
             if (!passwordEncoder.matches(userMeUpdateDto.getCurrentPassword(), me.getPassword())) {
-                errors.put("password", messageUtil.get("auth.invalid.password"));
+                errors.put("auth", messageUtil.get("auth.invalid.password"));
             }
         }
 

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -1,5 +1,6 @@
 package com.spaghetticodegang.trylater.user;
 
+import com.spaghetticodegang.trylater.shared.exception.PasswordErrorException;
 import com.spaghetticodegang.trylater.shared.exception.ValidationException;
 import com.spaghetticodegang.trylater.shared.util.MessageUtil;
 import com.spaghetticodegang.trylater.user.dto.UserMeRegistrationDto;
@@ -148,10 +149,10 @@ public class UserService implements UserDetailsService {
 
         if (isSensitiveChange) {
             if (userMeUpdateDto.getCurrentPassword() == null) {
-                errors.put("user", messageUtil.get("user.password.notblank"));
+                throw new PasswordErrorException("update.password.notblank");
             }
             if (!passwordEncoder.matches(userMeUpdateDto.getCurrentPassword(), me.getPassword())) {
-                errors.put("auth", messageUtil.get("auth.invalid.password"));
+                throw new UsernameNotFoundException("auth.invalid.credentials");
             }
         }
 

--- a/src/main/java/com/spaghetticodegang/trylater/user/dto/UserMeUpdateDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/dto/UserMeUpdateDto.java
@@ -9,18 +9,14 @@ import lombok.Setter;
 @Setter
 public class UserMeUpdateDto {
 
-    //@NotBlank(message = "{user.username.notblank}")
     @Size(min = 3, message = "{user.username.size}")
     private String userName;
 
-    //@NotBlank(message = "{user.displayname.notblank}")
     private String displayName;
 
-    //@NotBlank(message = "{user.email.notblank}")
     @Email(message = "{user.email.invalid}")
     private String email;
 
-    //@NotBlank(message = "{user.password.notblank}")
     @Size(min = 6, message = "{user.password.size}")
     private String currentPassword;
 

--- a/src/main/java/com/spaghetticodegang/trylater/user/dto/UserMeUpdateDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/dto/UserMeUpdateDto.java
@@ -1,0 +1,33 @@
+package com.spaghetticodegang.trylater.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserMeUpdateDto {
+
+    @NotBlank(message = "{user.username.notblank}")
+    @Size(min = 3, message = "{user.username.size}")
+    private String userName;
+
+    @NotBlank(message = "{user.displayname.notblank}")
+    private String displayName;
+
+    @NotBlank(message = "{user.email.notblank}")
+    @Email(message = "{user.email.invalid}")
+    private String email;
+
+    @NotBlank(message = "{user.password.notblank}")
+    @Size(min = 6, message = "{user.password.size}")
+    private String currentPassword;
+
+    @Size(min = 6, message = "{user.password.size}")
+    private String newPassword;
+
+    private String imgPath;
+
+}

--- a/src/main/java/com/spaghetticodegang/trylater/user/dto/UserMeUpdateDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/dto/UserMeUpdateDto.java
@@ -10,18 +10,18 @@ import lombok.Setter;
 @Setter
 public class UserMeUpdateDto {
 
-    @NotBlank(message = "{user.username.notblank}")
+    //@NotBlank(message = "{user.username.notblank}")
     @Size(min = 3, message = "{user.username.size}")
     private String userName;
 
-    @NotBlank(message = "{user.displayname.notblank}")
+    //@NotBlank(message = "{user.displayname.notblank}")
     private String displayName;
 
-    @NotBlank(message = "{user.email.notblank}")
+    //@NotBlank(message = "{user.email.notblank}")
     @Email(message = "{user.email.invalid}")
     private String email;
 
-    @NotBlank(message = "{user.password.notblank}")
+    //@NotBlank(message = "{user.password.notblank}")
     @Size(min = 6, message = "{user.password.size}")
     private String currentPassword;
 

--- a/src/main/java/com/spaghetticodegang/trylater/user/dto/UserMeUpdateDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/dto/UserMeUpdateDto.java
@@ -1,7 +1,6 @@
 package com.spaghetticodegang.trylater.user.dto;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -11,6 +11,7 @@ user.password.size=Passwort muss mindestens 6 Zeichen lang sein.
 user.not.found=Benutzer nicht gefunden.
 
 auth.invalid.credentials=Benutzername oder Passwort ungÃ¼ltig.
+auth.invalid.password=Passwort ungültig.
 
 contact.error.not.found=Der Kontakt wurde nicht gefunden.
 contact.error.user.not.found=Du bist diesem Kontakt nicht zugeordnet.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -45,6 +45,7 @@ recommendation.assignment.error.status.revert.to.sent=Statusänderung zu versende
 recommendation.assignment.error.not.found=Zugewiesene Empfehlung nicht gefunden.
 recommendation.not.found=Empfehlung nicht gefunden.
 
+update.password.notblank=Änderungen müssen mit Passwort bestätigt werden.
 
 exception.validation=Es sind Validierungsfehler aufgetreten.
 exception.badrequest=Die Anfrage war fehlerhaft oder unvollstÃ¤ndig.

--- a/src/test/java/com/spaghetticodegang/trylater/user/UserServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/user/UserServiceTest.java
@@ -184,7 +184,7 @@ class UserServiceTest {
         assertEquals("tester", result.getUserName());
         assertEquals("tester", result.getDisplayName());
         assertEquals("test@example.com", result.getEmail());
-        assertEquals(null, result.getImgPath());
+        assertNull(result.getImgPath());
     }
 
     @Test

--- a/src/test/java/com/spaghetticodegang/trylater/user/UserServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/user/UserServiceTest.java
@@ -181,7 +181,7 @@ class UserServiceTest {
         assertEquals("tester", result.getUserName());
         assertEquals("tester", result.getDisplayName());
         assertEquals("test@example.com", result.getEmail());
-        assertEquals("/assets/user.webp", result.getImgPath());
+        assertEquals(null, result.getImgPath());
     }
 
     @Test

--- a/src/test/java/com/spaghetticodegang/trylater/user/dto/UserMeUpdateDtoTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/user/dto/UserMeUpdateDtoTest.java
@@ -1,0 +1,78 @@
+package com.spaghetticodegang.trylater.user.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UserMeUpdateDtoTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    public static void setupValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void testValidDto() {
+        UserMeUpdateDto dto = new UserMeUpdateDto();
+        dto.setUserName("validUser");
+        dto.setDisplayName("Cool User");
+        dto.setEmail("user@example.com");
+        dto.setCurrentPassword("secret123");
+        dto.setNewPassword("newsecret");
+        dto.setImgPath("/images/user.jpg");
+
+        Set<ConstraintViolation<UserMeUpdateDto>> violations = validator.validate(dto);
+        assertTrue(violations.isEmpty(), "DTO should be valid");
+    }
+
+    @Test
+    public void testInvalidUserName() {
+        UserMeUpdateDto dto = new UserMeUpdateDto();
+        dto.setUserName("ab");
+        dto.setEmail("user@example.com");
+        dto.setCurrentPassword("secret123");
+        dto.setNewPassword("newsecret");
+
+        Set<ConstraintViolation<UserMeUpdateDto>> violations = validator.validate(dto);
+        assertEquals(1, violations.size());
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("userName")));
+    }
+
+    @Test
+    public void testInvalidEmail() {
+        UserMeUpdateDto dto = new UserMeUpdateDto();
+        dto.setUserName("validUser");
+        dto.setEmail("invalid-email");
+        dto.setCurrentPassword("secret123");
+        dto.setNewPassword("newsecret");
+
+        Set<ConstraintViolation<UserMeUpdateDto>> violations = validator.validate(dto);
+        assertEquals(1, violations.size());
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("email")));
+    }
+
+    @Test
+    public void testInvalidPasswords() {
+        UserMeUpdateDto dto = new UserMeUpdateDto();
+        dto.setUserName("validUser");
+        dto.setEmail("user@example.com");
+        dto.setCurrentPassword("123");
+        dto.setNewPassword("123");
+
+        Set<ConstraintViolation<UserMeUpdateDto>> violations = validator.validate(dto);
+        assertEquals(2, violations.size());
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("currentPassword")));
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("newPassword")));
+    }
+}


### PR DESCRIPTION
Umsetzung gemäß dem Ticket https://github.com/SpaghettiCodeGang/TryLater-Server/issues/47
Dazu für Änderung von Nutzername, Email und Passwort ist die Eingabe des aktuellen Passwortes notwendig
Für Änderung des Anzeigenamens  bzw. Bildes ist ohne Passwortbestätigung möglich.