### PR TITLE
Image deleting wenn objekte entfernt werden

### DIFF
--- a/src/main/java/com/spaghetticodegang/trylater/config/StaticResourceConfig.java
+++ b/src/main/java/com/spaghetticodegang/trylater/config/StaticResourceConfig.java
@@ -14,7 +14,7 @@ public class StaticResourceConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry
-                .addResourceHandler("/images/**")
+                .addResourceHandler("/api/images/**")
                 .addResourceLocations("file:" + uploadDir + "/");
     }
 }

--- a/src/main/java/com/spaghetticodegang/trylater/config/StaticResourceConfig.java
+++ b/src/main/java/com/spaghetticodegang/trylater/config/StaticResourceConfig.java
@@ -1,0 +1,20 @@
+package com.spaghetticodegang.trylater.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class StaticResourceConfig implements WebMvcConfigurer {
+
+    @Value("${image.upload.dir}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry
+                .addResourceHandler("/images/**")
+                .addResourceLocations("file:" + uploadDir + "/");
+    }
+}

--- a/src/main/java/com/spaghetticodegang/trylater/image/Image.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/Image.java
@@ -16,5 +16,5 @@ import lombok.*;
 public class Image {
 
     @Id
-    String imageId;
+    String imgPath;
 }

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageController.java
@@ -30,7 +30,7 @@ public class ImageController {
      * {@link ImageUploadResponseDto} in the body and an HTTP status code 201 (CREATED).
      *
      * @param request The {@link ImageUploadRequestDto} containing the image to be uploaded.
-     * This parameter is required and must be named "image" in the request.
+     * This parameter is required and must be named "imageFile" in the request.
      * @return A {@link ResponseEntity} containing an {@link ImageUploadResponseDto}
      * with the ID and path of the uploaded image and an HTTP status code 201 (CREATED).
      */
@@ -48,18 +48,14 @@ public class ImageController {
      * A successful upload and scaling operation results in a {@link ResponseEntity}
      * with an {@link ImageUploadResponseDto} and an HTTP status code 201 (CREATED).
      *
-     * @param imageFile    The {@link MultipartFile} containing the image to be uploaded and scaled.
-     * This parameter is required and must be named "image" in the request.
-     * @param targetWidth  The desired width of the scaled image, provided as a query parameter named "width".
-     * Must be a positive integer.
-     * @param targetHeight The desired height of the scaled image, provided as a query parameter named "height".
-     * Must be a positive integer.
+     * @param request The {@link ImageUploadRequestDto} containing the image to be uploaded.
+     * This parameter is required and must be named "imageFile" in the request.
      * @return A {@link ResponseEntity} containing an {@link ImageUploadResponseDto}
      * with the ID and path of the uploaded and scaled image and an HTTP status code 201 (CREATED).
      */
     @PostMapping("/scaling")
-    public ResponseEntity<ImageUploadResponseDto> uploadImageWithScaling(@RequestParam("image") MultipartFile imageFile, @RequestParam(name = "width") int targetWidth, @RequestParam(name = "height") int targetHeight) {
-        ImageUploadResponseDto imageUploadResponseDto = imageService.uploadImageWithScaling(imageFile, targetWidth, targetHeight);
+    public ResponseEntity<ImageUploadResponseDto> uploadImageWithScaling(@Valid @ModelAttribute ImageUploadRequestDto request) {
+        ImageUploadResponseDto imageUploadResponseDto = imageService.uploadImageWithScaling(request.getImageFile(), request.getTargetWidth(), request.getTargetHeight());
         return ResponseEntity.status(HttpStatus.CREATED).body(imageUploadResponseDto);
     }
 

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageController.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
  * and deleting images. All requests are mapped under the "/api/images" base path.
  */
 @RestController
-@RequestMapping("/api/images")
+@RequestMapping("/api/image")
 @RequiredArgsConstructor
 public class ImageController {
 

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageController.java
@@ -42,20 +42,20 @@ public class ImageController {
 
     /**
      * Handles the deletion of an image based on its unique ID.
-     * This endpoint accepts the image ID as a query parameter named "imageId"
-     * and delegates the deletion process to the {@link ImageService#deleteImageById(String)} method.
+     * This endpoint accepts the image ID as a query parameter named "imgPath"
+     * and delegates the deletion process to the {@link ImageService#deleteImageByImgPath(String)} method.
      * If the image is successfully deleted, it returns a {@link ResponseEntity}
      * with an HTTP status code 204 (NO_CONTENT). If the image with the given ID
      * is not found, it returns a {@link ResponseEntity} with an HTTP status code 404 (NOT_FOUND).
      *
-     * @param id The unique identifier of the image to be deleted, provided as a query parameter named "imageId".
+     * @param id The unique identifier of the image to be deleted, provided as a query parameter named "imgPath".
      * Must not be {@code null} or empty.
      * @return A {@link ResponseEntity} with HTTP status code 204 (NO_CONTENT) if the image was
      * successfully deleted, or 404 (NOT_FOUND) if the image with the given ID does not exist.
      */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteImage(@PathVariable("id") String id) {
-        boolean isDeleted = imageService.deleteImageById(id);
+        boolean isDeleted = imageService.deleteImageByImgPath(id);
 
         if (!isDeleted) {
             return ResponseEntity.notFound().build();

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageController.java
@@ -1,7 +1,9 @@
 package com.spaghetticodegang.trylater.image;
 
 
+import com.spaghetticodegang.trylater.image.dto.ImageUploadRequestDto;
 import com.spaghetticodegang.trylater.image.dto.ImageUploadResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -27,14 +29,14 @@ public class ImageController {
      * Upon successful upload, it returns a {@link ResponseEntity} with an
      * {@link ImageUploadResponseDto} in the body and an HTTP status code 201 (CREATED).
      *
-     * @param imageFile The {@link MultipartFile} containing the image to be uploaded.
+     * @param request The {@link ImageUploadRequestDto} containing the image to be uploaded.
      * This parameter is required and must be named "image" in the request.
      * @return A {@link ResponseEntity} containing an {@link ImageUploadResponseDto}
      * with the ID and path of the uploaded image and an HTTP status code 201 (CREATED).
      */
     @PostMapping
-    public ResponseEntity<ImageUploadResponseDto> uploadImage(@RequestParam("image") MultipartFile imageFile) {
-        ImageUploadResponseDto imageUploadResponseDto = imageService.uploadImage(imageFile);
+    public ResponseEntity<ImageUploadResponseDto> uploadImage(@Valid @ModelAttribute ImageUploadRequestDto request) {
+        ImageUploadResponseDto imageUploadResponseDto = imageService.uploadImage(request.getImageFile());
         return ResponseEntity.status(HttpStatus.CREATED).body(imageUploadResponseDto);
     }
 
@@ -74,8 +76,8 @@ public class ImageController {
      * @return A {@link ResponseEntity} with HTTP status code 204 (NO_CONTENT) if the image was
      * successfully deleted, or 404 (NOT_FOUND) if the image with the given ID does not exist.
      */
-    @DeleteMapping
-    public ResponseEntity<Void> deleteImage(@RequestParam("imageId") String id) {
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteImage(@PathVariable("id") String id) {
         boolean isDeleted = imageService.deleteImageById(id);
 
         if (!isDeleted) {

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageController.java
@@ -41,25 +41,6 @@ public class ImageController {
     }
 
     /**
-     * Handles the upload and scaling of an image file.
-     * This endpoint accepts a multipart file named "image" along with the desired
-     * target width and height as query parameters. It delegates the processing
-     * to the {@link ImageService#uploadImageWithScaling(MultipartFile, int, int)} method.
-     * A successful upload and scaling operation results in a {@link ResponseEntity}
-     * with an {@link ImageUploadResponseDto} and an HTTP status code 201 (CREATED).
-     *
-     * @param request The {@link ImageUploadRequestDto} containing the image to be uploaded.
-     * This parameter is required and must be named "imageFile" in the request.
-     * @return A {@link ResponseEntity} containing an {@link ImageUploadResponseDto}
-     * with the ID and path of the uploaded and scaled image and an HTTP status code 201 (CREATED).
-     */
-    @PostMapping("/scaling")
-    public ResponseEntity<ImageUploadResponseDto> uploadImageWithScaling(@Valid @ModelAttribute ImageUploadRequestDto request) {
-        ImageUploadResponseDto imageUploadResponseDto = imageService.uploadImageWithScaling(request.getImageFile(), request.getTargetWidth(), request.getTargetHeight());
-        return ResponseEntity.status(HttpStatus.CREATED).body(imageUploadResponseDto);
-    }
-
-    /**
      * Handles the deletion of an image based on its unique ID.
      * This endpoint accepts the image ID as a query parameter named "imageId"
      * and delegates the deletion process to the {@link ImageService#deleteImageById(String)} method.

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
@@ -4,13 +4,10 @@ import com.spaghetticodegang.trylater.shared.exception.ImageHandleException;
 import com.spaghetticodegang.trylater.shared.util.MessageUtil;
 import com.spaghetticodegang.trylater.image.dto.ImageUploadResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.imgscalr.Scalr;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
@@ -38,13 +38,12 @@ public class ImageService {
      * such as its unique ID and the full path where it is stored.
      *
      * @param image The {@link Image} entity representing the uploaded image.
-     * Must not be {@code null}.
+     *              Must not be {@code null}.
      * @return An {@link ImageUploadResponseDto} containing the image ID and its storage path.
      */
     public ImageUploadResponseDto createImageUploadResponseDto(Image image) {
         return ImageUploadResponseDto.builder()
                 .imageId(image.getImageId())
-                .imagePath(uploadDir + image.getImageId())
                 .build();
     }
 
@@ -63,10 +62,10 @@ public class ImageService {
      * </ol>
      *
      * @param imageFile The {@link MultipartFile} representing the image to be uploaded.
-     * Must not be {@code null} or empty.
+     *                  Must not be {@code null} or empty.
      * @return An {@link ImageUploadResponseDto} with the ID and path of the uploaded image.
      * @throws ImageHandleException If the provided file is empty, has an unsupported format,
-     * or if an {@link IOException} occurs during file handling.
+     *                              or if an {@link IOException} occurs during file handling.
      */
     public ImageUploadResponseDto uploadImage(MultipartFile imageFile) {
         try {
@@ -89,61 +88,12 @@ public class ImageService {
     }
 
     /**
-     * Uploads and scales an image file to the specified target width and height.
-     * This method performs the following actions:
-     * <ol>
-     * <li>Validates the uploaded {@link MultipartFile} for emptiness and supported image format (png, jpeg, jpg, webp).</li>
-     * <li>Generates a unique filename for the scaled image.</li>
-     * <li>Creates the necessary directories for storage.</li>
-     * <li>Reads the input {@link MultipartFile} into a {@link BufferedImage}.</li>
-     * <li>Resizes the {@link BufferedImage} to the given {@code targetWidth} and {@code targetHeight}
-     * using the {@link Scalr} library with {@link Scalr.Mode#FIT_EXACT}.</li>
-     * <li>Writes the resized image to the storage location in the original image format.</li>
-     * <li>Creates and saves a new {@link Image} entity with the generated filename.</li>
-     * <li>Returns an {@link ImageUploadResponseDto} containing the ID and path of the scaled and uploaded image.</li>
-     * </ol>
-     *
-     * @param imageFile   The {@link MultipartFile} of the image to upload and scale.
-     * Must not be {@code null} or empty.
-     * @param targetWidth The desired width of the scaled image in pixels. Must be a positive integer.
-     * @param targetHeight The desired height of the scaled image in pixels. Must be a positive integer.
-     * @return An {@link ImageUploadResponseDto} with the ID and path of the uploaded and scaled image.
-     * @throws ImageHandleException If the uploaded file is empty, has an unsupported format,
-     * cannot be read as an image, or if an {@link IOException} occurs
-     * during file reading or writing.
-     */
-    public ImageUploadResponseDto uploadImageWithScaling(MultipartFile imageFile, int targetWidth, int targetHeight) {
-        try {
-            final String imageType = validateImage(imageFile);
-            final String imageName = UUID.randomUUID() + "." + imageType;
-            Path path = Paths.get(uploadDir, imageName);
-            Files.createDirectories(path.getParent());
-            BufferedImage originalImage = ImageIO.read(imageFile.getInputStream());
-            if (originalImage == null) {
-                throw new ImageHandleException(Map.of("image", messageUtil.get("image.upload.error") + messageUtil.get("image.upload.read.error")));
-            }
-            BufferedImage resizedImage = resizeImage(originalImage, targetWidth, targetHeight);
-            ImageIO.write(resizedImage, imageType, path.toFile());
-
-            final Image image = Image.builder()
-                    .imageId(imageName)
-                    .build();
-
-            imageRepository.save(image);
-
-            return createImageUploadResponseDto(image);
-        } catch (IOException e) {
-            throw new ImageHandleException(Map.of("image", messageUtil.get("image.upload.error") + e.getMessage()));
-        }
-    }
-
-    /**
      * Deletes an image file from the file system based on its unique ID.
      * This method attempts to delete the file located at the path constructed
      * using the configured upload directory and the provided {@code imageId}.
      *
      * @param imageId The unique identifier of the image to be deleted.
-     * This should match the filename (including extension) of the image file.
+     *                This should match the filename (including extension) of the image file.
      * @return {@code true} if the image file was successfully deleted;
      * {@code false} if the file does not exist.
      * @throws ImageHandleException If an {@link IOException} occurs during the deletion process.
@@ -154,6 +104,7 @@ public class ImageService {
             return false;
         }
         try {
+            imageRepository.deleteById(imageId);
             return Files.deleteIfExists(filePath);
         } catch (IOException e) {
             throw new ImageHandleException(Map.of("image", messageUtil.get("image.delete.error") + e.getMessage()));
@@ -167,7 +118,7 @@ public class ImageService {
      * If no dot is found, an empty string is returned.
      *
      * @param imageName The filename from which to extract the image type.
-     * Should not be {@code null}.
+     *                  Should not be {@code null}.
      * @return The lowercase file extension (e.g., "png", "jpg"), or an empty string if no extension is found.
      */
     private static String getImageType(String imageName) {
@@ -179,29 +130,15 @@ public class ImageService {
     }
 
     /**
-     * Resizes a {@link BufferedImage} to the exact target width and height using the {@link Scalr} library.
-     * The {@link Scalr.Mode#FIT_EXACT} ensures that the resulting image has precisely the specified dimensions,
-     * potentially stretching or compressing the original image to fit.
-     *
-     * @param originalImage The {@link BufferedImage} to be resized. Must not be {@code null}.
-     * @param targetWidth   The desired width of the resized image in pixels. Must be a positive integer.
-     * @param targetHeight  The desired height of the resized image in pixels. Must be a positive integer.
-     * @return A new {@link BufferedImage} that has been resized to the target dimensions.
-     */
-    private BufferedImage resizeImage(BufferedImage originalImage, int targetWidth, int targetHeight) {
-        return Scalr.resize(originalImage, Scalr.Mode.FIT_EXACT, targetWidth, targetHeight);
-    }
-
-    /**
      * Validates a given {@link MultipartFile} to ensure it is not null or empty
      * and that its original filename has a supported image file extension (png, jpeg, jpg, webp).
      * If the file is invalid, an {@link ImageHandleException} is thrown.
      *
      * @param imageFile The {@link MultipartFile} to be validated.
-     * Must not be {@code null}.
+     *                  Must not be {@code null}.
      * @return The lowercase image type (file extension) if the validation is successful.
      * @throws ImageHandleException If the file is null or empty, or if its filename
-     * does not have a supported image file extension.
+     *                              does not have a supported image file extension.
      */
     private String validateImage(MultipartFile imageFile) {
         final String imageType = getImageType(Objects.requireNonNull(imageFile.getOriginalFilename()));

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
@@ -40,7 +40,7 @@ public class ImageService {
      */
     public ImageUploadResponseDto createImageUploadResponseDto(Image image) {
         return ImageUploadResponseDto.builder()
-                .imagePath(image.getImageId())
+                .imgPath(image.getImgPath())
                 .build();
     }
 
@@ -73,7 +73,7 @@ public class ImageService {
             imageFile.transferTo(path);
 
             final Image image = Image.builder()
-                    .imageId(imageName)
+                    .imgPath(imageName)
                     .build();
 
             imageRepository.save(image);
@@ -87,21 +87,21 @@ public class ImageService {
     /**
      * Deletes an image file from the file system based on its unique ID.
      * This method attempts to delete the file located at the path constructed
-     * using the configured upload directory and the provided {@code imageId}.
+     * using the configured upload directory and the provided {@code imgPath}.
      *
-     * @param imageId The unique identifier of the image to be deleted.
+     * @param imgPath The unique identifier of the image to be deleted.
      *                This should match the filename (including extension) of the image file.
      * @return {@code true} if the image file was successfully deleted;
      * {@code false} if the file does not exist.
      * @throws ImageHandleException If an {@link IOException} occurs during the deletion process.
      */
-    public boolean deleteImageById(String imageId) {
-        Path filePath = Paths.get(uploadDir, imageId);
+    public boolean deleteImageByImgPath(String imgPath) {
+        Path filePath = Paths.get(uploadDir, imgPath);
         if (!Files.exists(filePath)) {
             return false;
         }
         try {
-            imageRepository.deleteById(imageId);
+            imageRepository.deleteById(imgPath);
             return Files.deleteIfExists(filePath);
         } catch (IOException e) {
             throw new ImageHandleException(Map.of("image", messageUtil.get("image.delete.error") + e.getMessage()));

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
@@ -3,6 +3,7 @@ package com.spaghetticodegang.trylater.image;
 import com.spaghetticodegang.trylater.shared.exception.ImageHandleException;
 import com.spaghetticodegang.trylater.shared.util.MessageUtil;
 import com.spaghetticodegang.trylater.image.dto.ImageUploadResponseDto;
+import lombok.Generated;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -40,7 +41,7 @@ public class ImageService {
      */
     public ImageUploadResponseDto createImageUploadResponseDto(Image image) {
         return ImageUploadResponseDto.builder()
-                .imageId(image.getImageId())
+                .imagePath(image.getImageId())
                 .build();
     }
 

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
@@ -3,7 +3,6 @@ package com.spaghetticodegang.trylater.image;
 import com.spaghetticodegang.trylater.shared.exception.ImageHandleException;
 import com.spaghetticodegang.trylater.shared.util.MessageUtil;
 import com.spaghetticodegang.trylater.image.dto.ImageUploadResponseDto;
-import lombok.Generated;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/ImageService.java
@@ -204,10 +204,6 @@ public class ImageService {
      * does not have a supported image file extension.
      */
     private String validateImage(MultipartFile imageFile) {
-        if (imageFile == null || imageFile.isEmpty()) {
-            throw new ImageHandleException(Map.of("image", messageUtil.get("image.is.empty")));
-        }
-
         final String imageType = getImageType(Objects.requireNonNull(imageFile.getOriginalFilename()));
         final Set<String> allowedTypesSet = new HashSet<>(Arrays.asList("png", "jpeg", "jpg", "webp"));
 

--- a/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadRequestDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadRequestDto.java
@@ -12,7 +12,4 @@ import org.springframework.web.multipart.MultipartFile;
 public class ImageUploadRequestDto {
     @NotNull(message = "{image.no.file}")
     private MultipartFile imageFile;
-
-    private Integer targetWidth;
-    private Integer targetHeight;
 }

--- a/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadRequestDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadRequestDto.java
@@ -1,0 +1,17 @@
+package com.spaghetticodegang.trylater.image.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@Builder
+public class ImageUploadRequestDto {
+    @NotNull(message = "{image.no.file}")
+    @NotEmpty(message = "{image.is.empty}")
+    private MultipartFile imageFile;
+}

--- a/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadRequestDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadRequestDto.java
@@ -1,6 +1,5 @@
 package com.spaghetticodegang.trylater.image.dto;
 
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +11,8 @@ import org.springframework.web.multipart.MultipartFile;
 @Builder
 public class ImageUploadRequestDto {
     @NotNull(message = "{image.no.file}")
-    @NotEmpty(message = "{image.is.empty}")
     private MultipartFile imageFile;
+
+    private Integer targetWidth;
+    private Integer targetHeight;
 }

--- a/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDto.java
@@ -11,6 +11,5 @@ import lombok.Setter;
 public class ImageUploadResponseDto {
 
     private String imageId;
-    private String imagePath;
 
 }

--- a/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDto.java
@@ -10,6 +10,6 @@ import lombok.Setter;
 @Builder
 public class ImageUploadResponseDto {
 
-    private String imageId;
+    private String imagePath;
 
 }

--- a/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDto.java
@@ -10,6 +10,6 @@ import lombok.Setter;
 @Builder
 public class ImageUploadResponseDto {
 
-    private String imagePath;
+    private String imgPath;
 
 }

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationController.java
@@ -54,7 +54,7 @@ public class RecommendationController {
     /**
      * Handles request to get all assigned recommendations by delegating to the service layer.
      *
-     * @param me the currently authenticated user (requester)
+     * @param me                             the currently authenticated user (requester)
      * @param recommendationAssignmentStatus the status of the assignment
      * @return a list of all the assigned recommendation with that specified status
      */
@@ -63,11 +63,11 @@ public class RecommendationController {
         return ResponseEntity.ok(recommendationService.getAllRecommendationsByUserAndRecommendationStatus(me, recommendationAssignmentStatus));
     }
 
-     /**
+    /**
      * Deletes a recommendation assignment by delegating to the service layer.
      *
-     * @param me                             the currently authenticated user (requester)
-     * @param recommendationId     the ID of the recommendation that assignment should delete
+     * @param me               the currently authenticated user (requester)
+     * @param recommendationId the ID of the recommendation that assignment should delete
      * @return A {@link ResponseEntity} with HTTP status code 204 (NO_CONTENT)
      */
     @DeleteMapping("/assignment/{id}")

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationService.java
@@ -1,6 +1,7 @@
 package com.spaghetticodegang.trylater.recommendation;
 
 import com.spaghetticodegang.trylater.contact.ContactService;
+import com.spaghetticodegang.trylater.image.ImageService;
 import com.spaghetticodegang.trylater.recommendation.assignment.RecommendationAssignment;
 import com.spaghetticodegang.trylater.recommendation.assignment.RecommendationAssignmentService;
 import com.spaghetticodegang.trylater.recommendation.assignment.RecommendationAssignmentStatus;
@@ -37,6 +38,7 @@ public class RecommendationService {
     private final TagService tagService;
     private final UserService userService;
     private final ContactService contactService;
+    private final ImageService imageService;
     private final MessageUtil messageUtil;
 
     /**
@@ -185,6 +187,10 @@ public class RecommendationService {
     public void deleteRecommendationAssignment(User me, Long recommendationId) {
         recommendationAssignmentService.deleteRecommendationAssignmentByRecommendationId(me.getId(), recommendationId);
         if (!recommendationAssignmentService.existsRecommendationInRecommendationAssignment(recommendationId)) {
+            String imagePath = recommendationRepository.findById(recommendationId).get().getImgPath();
+            if (imagePath != null) {
+                imageService.deleteImageById(imagePath);
+            }
             recommendationRepository.deleteById(recommendationId);
         }
     }

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationService.java
@@ -187,7 +187,7 @@ public class RecommendationService {
     public void deleteRecommendationAssignment(User me, Long recommendationId) {
         recommendationAssignmentService.deleteRecommendationAssignmentByRecommendationId(me.getId(), recommendationId);
         if (!recommendationAssignmentService.existsRecommendationInRecommendationAssignment(recommendationId)) {
-            String imagePath = recommendationRepository.findById(recommendationId).get().getImgPath();
+            String imagePath = getRecommendationById(recommendationId).getImgPath();
             if (imagePath != null) {
                 imageService.deleteImageById(imagePath);
             }

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationService.java
@@ -189,7 +189,7 @@ public class RecommendationService {
         if (!recommendationAssignmentService.existsRecommendationInRecommendationAssignment(recommendationId)) {
             String imagePath = getRecommendationById(recommendationId).getImgPath();
             if (imagePath != null) {
-                imageService.deleteImageById(imagePath);
+                imageService.deleteImageByImgPath(imagePath);
             }
             recommendationRepository.deleteById(recommendationId);
         }

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -1,5 +1,6 @@
 package com.spaghetticodegang.trylater.user;
 
+import com.spaghetticodegang.trylater.image.ImageService;
 import com.spaghetticodegang.trylater.shared.exception.PasswordErrorException;
 import com.spaghetticodegang.trylater.shared.exception.ValidationException;
 import com.spaghetticodegang.trylater.shared.util.MessageUtil;
@@ -26,6 +27,7 @@ import java.util.Map;
 public class UserService implements UserDetailsService {
 
     private final UserRepository userRepository;
+    private final ImageService imageService;
     private final PasswordEncoder passwordEncoder;
     private final MessageUtil messageUtil;
 
@@ -193,6 +195,10 @@ public class UserService implements UserDetailsService {
         }
 
         if (userMeUpdateDto.getImgPath() != null) {
+            String currentImagePath = findUserById(me.getId()).getImgPath();
+            if (currentImagePath != null) {
+                imageService.deleteImageById(currentImagePath);
+            }
             me.setImgPath(userMeUpdateDto.getImgPath());
         }
 

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -197,7 +197,7 @@ public class UserService implements UserDetailsService {
         if (userMeUpdateDto.getImgPath() != null) {
             String currentImagePath = findUserById(me.getId()).getImgPath();
             if (currentImagePath != null) {
-                imageService.deleteImageById(currentImagePath);
+                imageService.deleteImageByImgPath(currentImagePath);
             }
             me.setImgPath(userMeUpdateDto.getImgPath());
         }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -20,7 +20,8 @@ contact.error.already.exists=Der Kontakt besteht bereits oder wurde bereits ange
 contact.error.self.update.status=Du darfst den Status deiner eigenen Kontaktanfrage nicht ändern.
 contact.error.status.revert.to.pending=Der Status einer Kontaktanfrage kann nicht wieder auf "ausstehend" gesetzt werden.
 
-image.is.empty=Kein Bild hochgeladen.
+image.no.file=Kein Bild hochgeladen.
+image.is.empty=Leere Bilddatei hochgeladen.
 image.wrong.type=Nur jpg und png erlaubt.
 image.upload.exceed.max.size=Die hochgeladene Datei ist zu groß. Die maximale Dateigröße beträgt 10MB.
 image.upload.error=Es sind Fehler während des Uploads aufgetreten:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -21,7 +21,6 @@ contact.error.self.update.status=Du darfst den Status deiner eigenen Kontaktanfr
 contact.error.status.revert.to.pending=Der Status einer Kontaktanfrage kann nicht wieder auf "ausstehend" gesetzt werden.
 
 image.no.file=Kein Bild hochgeladen.
-image.is.empty=Leere Bilddatei hochgeladen.
 image.wrong.type=Nur jpg und png erlaubt.
 image.upload.exceed.max.size=Die hochgeladene Datei ist zu groß. Die maximale Dateigröße beträgt 10MB.
 image.upload.error=Es sind Fehler während des Uploads aufgetreten:

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageControllerTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageControllerTest.java
@@ -34,7 +34,7 @@ public class ImageControllerTest {
         mockRequestDto.setImageFile(mockImageFile);
 
         ImageUploadResponseDto mockResponseDto = ImageUploadResponseDto.builder()
-                .imagePath("generatedId")
+                .imgPath("generatedId")
                 .build();
 
         when(imageService.uploadImage(mockImageFile)).thenReturn(mockResponseDto);
@@ -48,23 +48,23 @@ public class ImageControllerTest {
 
     @Test
     void deleteImage_success() {
-        String imageIdToDelete = "existingImageId";
-        when(imageService.deleteImageById(imageIdToDelete)).thenReturn(true);
+        String imgPathToDelete = "existingImgPath";
+        when(imageService.deleteImageByImgPath(imgPathToDelete)).thenReturn(true);
 
-        ResponseEntity<Void> response = imageController.deleteImage(imageIdToDelete);
+        ResponseEntity<Void> response = imageController.deleteImage(imgPathToDelete);
 
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
-        verify(imageService, times(1)).deleteImageById(imageIdToDelete);
+        verify(imageService, times(1)).deleteImageByImgPath(imgPathToDelete);
     }
 
     @Test
     void deleteImage_notFound() {
-        String nonExistingImageId = "nonExistingId";
-        when(imageService.deleteImageById(nonExistingImageId)).thenReturn(false);
+        String nonExistingImgPath = "nonExistingId";
+        when(imageService.deleteImageByImgPath(nonExistingImgPath)).thenReturn(false);
 
-        ResponseEntity<Void> response = imageController.deleteImage(nonExistingImageId);
+        ResponseEntity<Void> response = imageController.deleteImage(nonExistingImgPath);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        verify(imageService, times(1)).deleteImageById(nonExistingImageId);
+        verify(imageService, times(1)).deleteImageByImgPath(nonExistingImgPath);
     }
 }

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageControllerTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageControllerTest.java
@@ -1,5 +1,6 @@
 package com.spaghetticodegang.trylater.image;
 
+import com.spaghetticodegang.trylater.image.dto.ImageUploadRequestDto;
 import com.spaghetticodegang.trylater.image.dto.ImageUploadResponseDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +27,12 @@ public class ImageControllerTest {
     @Test
     void uploadImage_success() {
         MultipartFile mockImageFile = new MockMultipartFile("image", "test.png", "image/png", "some image data".getBytes());
+        ImageUploadRequestDto mockRequestDto = ImageUploadRequestDto.builder()
+                .imageFile(mockImageFile)
+                .build();
+
+        mockRequestDto.setImageFile(mockImageFile);
+
         ImageUploadResponseDto mockResponseDto = ImageUploadResponseDto.builder()
                 .imageId("generatedId")
                 .imagePath("/path/to/generatedId.png")
@@ -33,7 +40,7 @@ public class ImageControllerTest {
 
         when(imageService.uploadImage(mockImageFile)).thenReturn(mockResponseDto);
 
-        ResponseEntity<ImageUploadResponseDto> response = imageController.uploadImage(mockImageFile);
+        ResponseEntity<ImageUploadResponseDto> response = imageController.uploadImage(mockRequestDto);
 
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertEquals(mockResponseDto, response.getBody());

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageControllerTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageControllerTest.java
@@ -35,7 +35,6 @@ public class ImageControllerTest {
 
         ImageUploadResponseDto mockResponseDto = ImageUploadResponseDto.builder()
                 .imageId("generatedId")
-                .imagePath("/path/to/generatedId.png")
                 .build();
 
         when(imageService.uploadImage(mockImageFile)).thenReturn(mockResponseDto);
@@ -45,34 +44,6 @@ public class ImageControllerTest {
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertEquals(mockResponseDto, response.getBody());
         verify(imageService, times(1)).uploadImage(mockImageFile);
-    }
-
-    @Test
-    void uploadImageWithScaling_success() {
-        MultipartFile mockImageFile = new MockMultipartFile("image", "test.jpg", "image/jpeg", "other image data".getBytes());
-        int targetWidth = 100;
-        int targetHeight = 100;
-
-        ImageUploadRequestDto mockRequestDto = ImageUploadRequestDto.builder()
-                .imageFile(mockImageFile)
-                .build();
-
-        mockRequestDto.setImageFile(mockImageFile);
-        mockRequestDto.setTargetWidth(targetWidth);
-        mockRequestDto.setTargetHeight(targetHeight);
-
-        ImageUploadResponseDto mockResponseDto = ImageUploadResponseDto.builder()
-                .imageId("scaledId")
-                .imagePath("/path/to/scaledId_scaled.jpg")
-                .build();
-
-        when(imageService.uploadImageWithScaling(mockImageFile, targetWidth, targetHeight)).thenReturn(mockResponseDto);
-
-        ResponseEntity<ImageUploadResponseDto> response = imageController.uploadImageWithScaling(mockRequestDto);
-
-        assertEquals(HttpStatus.CREATED, response.getStatusCode());
-        assertEquals(mockResponseDto, response.getBody());
-        verify(imageService, times(1)).uploadImageWithScaling(mockImageFile, targetWidth, targetHeight);
     }
 
     @Test

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageControllerTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageControllerTest.java
@@ -34,7 +34,7 @@ public class ImageControllerTest {
         mockRequestDto.setImageFile(mockImageFile);
 
         ImageUploadResponseDto mockResponseDto = ImageUploadResponseDto.builder()
-                .imageId("generatedId")
+                .imagePath("generatedId")
                 .build();
 
         when(imageService.uploadImage(mockImageFile)).thenReturn(mockResponseDto);

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageControllerTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageControllerTest.java
@@ -52,6 +52,15 @@ public class ImageControllerTest {
         MultipartFile mockImageFile = new MockMultipartFile("image", "test.jpg", "image/jpeg", "other image data".getBytes());
         int targetWidth = 100;
         int targetHeight = 100;
+
+        ImageUploadRequestDto mockRequestDto = ImageUploadRequestDto.builder()
+                .imageFile(mockImageFile)
+                .build();
+
+        mockRequestDto.setImageFile(mockImageFile);
+        mockRequestDto.setTargetWidth(targetWidth);
+        mockRequestDto.setTargetHeight(targetHeight);
+
         ImageUploadResponseDto mockResponseDto = ImageUploadResponseDto.builder()
                 .imageId("scaledId")
                 .imagePath("/path/to/scaledId_scaled.jpg")
@@ -59,7 +68,7 @@ public class ImageControllerTest {
 
         when(imageService.uploadImageWithScaling(mockImageFile, targetWidth, targetHeight)).thenReturn(mockResponseDto);
 
-        ResponseEntity<ImageUploadResponseDto> response = imageController.uploadImageWithScaling(mockImageFile, targetWidth, targetHeight);
+        ResponseEntity<ImageUploadResponseDto> response = imageController.uploadImageWithScaling(mockRequestDto);
 
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertEquals(mockResponseDto, response.getBody());

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageRepositoryTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageRepositoryTest.java
@@ -23,20 +23,20 @@ public class ImageRepositoryTest {
     @Test
     void testSaveAndFindById() {
         Image image = Image.builder()
-                .imageId("test-image-123")
+                .imgPath("test-image-123")
                 .build();
 
         Image savedImage = imageRepository.save(image);
-        Optional<Image> foundImage = imageRepository.findById(savedImage.getImageId());
+        Optional<Image> foundImage = imageRepository.findById(savedImage.getImgPath());
 
         assertTrue(foundImage.isPresent());
-        assertEquals(image.getImageId(), foundImage.get().getImageId());
+        assertEquals(image.getImgPath(), foundImage.get().getImgPath());
     }
 
     @Test
     void testExistsById() {
         Image image = Image.builder()
-                .imageId("existing-image")
+                .imgPath("existing-image")
                 .build();
         entityManager.persist(image);
         entityManager.flush();
@@ -51,7 +51,7 @@ public class ImageRepositoryTest {
     @Test
     void testDeleteById() {
         Image image = Image.builder()
-                .imageId("to-be-deleted")
+                .imgPath("to-be-deleted")
                 .build();
         entityManager.persist(image);
         entityManager.flush();
@@ -65,7 +65,7 @@ public class ImageRepositoryTest {
     @Test
     void testDelete() {
         Image image = Image.builder()
-                .imageId("another-delete")
+                .imgPath("another-delete")
                 .build();
         entityManager.persist(image);
         entityManager.flush();

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
@@ -14,7 +14,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.imageio.ImageIO;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -38,9 +37,6 @@ class ImageServiceTest {
 
     @Mock
     private MessageUtil messageUtil;
-
-    @Captor
-    private ArgumentCaptor<Image> imageArgumentCaptor;
 
     private final String TEST_UPLOAD_DIR = "test-upload/";
     private final String TEST_IMAGE_NAME = "test-image.png";

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
@@ -53,7 +53,7 @@ class ImageServiceTest {
         }
     }
 
-    private String getImageIdFromUpload(MultipartFile file) {
+    private String getimgPathFromUpload(MultipartFile file) {
         String originalFilename = Objects.requireNonNull(file.getOriginalFilename());
         String imageType = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
         return UUID.randomUUID() + "." + imageType;
@@ -74,10 +74,10 @@ class ImageServiceTest {
             ImageUploadResponseDto responseDto = imageService.uploadImage(mockImageFile);
 
             assertNotNull(responseDto);
-            assertEquals(expectedImageName, responseDto.getImagePath());
+            assertEquals(expectedImageName, responseDto.getImgPath());
 
             verify(imageRepository, times(1)).save(imageCaptor.capture());
-            assertEquals(expectedImageName, imageCaptor.getValue().getImageId());
+            assertEquals(expectedImageName, imageCaptor.getValue().getImgPath());
 
             verify(messageUtil, never()).get(anyString());
             Path path = Paths.get(expectedImagePath);
@@ -96,7 +96,7 @@ class ImageServiceTest {
 
         verify(imageRepository, never()).save(any());
         verify(messageUtil, times(1)).get("image.wrong.type");
-        assertFalse(Files.exists(testUploadDirPath.resolve(getImageIdFromUpload(mockImageFile))));
+        assertFalse(Files.exists(testUploadDirPath.resolve(getimgPathFromUpload(mockImageFile))));
     }
 
     @Test
@@ -112,7 +112,7 @@ class ImageServiceTest {
         verify(imageRepository, never()).save(any());
         verify(messageUtil, times(1)).get("image.upload.error");
         verify(mockImageFile, times(1)).transferTo(any(Path.class));
-        assertFalse(Files.exists(testUploadDirPath.resolve(getImageIdFromUpload(mockImageFile))));
+        assertFalse(Files.exists(testUploadDirPath.resolve(getimgPathFromUpload(mockImageFile))));
     }
 
     @Test
@@ -121,7 +121,7 @@ class ImageServiceTest {
         Path filePath = Paths.get(TEST_UPLOAD_DIR, testUuid);
         Files.createFile(filePath);
         when(messageUtil.get("image.delete.error")).thenReturn("Failed to delete image.");
-        boolean result = imageService.deleteImageById(testUuid);
+        boolean result = imageService.deleteImageByImgPath(testUuid);
 
         assertTrue(result);
         assertFalse(Files.exists(filePath));
@@ -132,7 +132,7 @@ class ImageServiceTest {
         String nonExistingUuid = "non-existing-uuid.png";
         Path filePath = Paths.get(TEST_UPLOAD_DIR, nonExistingUuid);
         when(messageUtil.get("image.delete.error")).thenReturn("Failed to delete image.");
-        boolean result = imageService.deleteImageById(nonExistingUuid);
+        boolean result = imageService.deleteImageByImgPath(nonExistingUuid);
 
         assertFalse(result);
         assertFalse(Files.exists(filePath));
@@ -140,8 +140,8 @@ class ImageServiceTest {
 
     @Test
     void deleteImageById_shouldThrowException_whenIOExceptionOccurs(){
-        String imageId = "test-image.jpg";
-        Path filePath = Paths.get(TEST_UPLOAD_DIR, imageId);
+        String imgPath = "test-image.jpg";
+        Path filePath = Paths.get(TEST_UPLOAD_DIR, imgPath);
 
         when(messageUtil.get("image.delete.error")).thenReturn("Failed to delete image.");
 
@@ -151,7 +151,7 @@ class ImageServiceTest {
                     .thenThrow(new IOException("Access denied."));
 
             assertThrows(ImageHandleException.class, () -> {
-                imageService.deleteImageById(imageId);
+                imageService.deleteImageByImgPath(imgPath);
             });
         }
     }

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
@@ -74,7 +74,7 @@ class ImageServiceTest {
             ImageUploadResponseDto responseDto = imageService.uploadImage(mockImageFile);
 
             assertNotNull(responseDto);
-            assertEquals(expectedImageName, responseDto.getImageId());
+            assertEquals(expectedImageName, responseDto.getImagePath());
 
             verify(imageRepository, times(1)).save(imageCaptor.capture());
             assertEquals(expectedImageName, imageCaptor.getValue().getImageId());

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
@@ -91,19 +91,6 @@ class ImageServiceTest {
     }
 
     @Test
-    void uploadImage_emptyFile_throwsImageHandleException() {
-        MultipartFile mockImageFile = new MockMultipartFile("image", TEST_IMAGE_NAME, "image/png", new byte[0]);
-        when(messageUtil.get("image.is.empty")).thenReturn("Image file is empty.");
-
-        ImageHandleException exception = assertThrows(ImageHandleException.class, () -> imageService.uploadImage(mockImageFile));
-        assertEquals("Image file is empty.", exception.getErrors().get("image"));
-
-        verify(imageRepository, never()).save(any());
-        verify(messageUtil, times(1)).get("image.is.empty");
-        assertFalse(Files.exists(testUploadDirPath.resolve(getImageIdFromUpload(mockImageFile))));
-    }
-
-    @Test
     void uploadImage_wrongType_throwsImageHandleException() {
         MultipartFile mockImageFile = new MockMultipartFile("image", "test-image.gif", "image/gif", TEST_IMAGE_DATA);
         when(messageUtil.get("image.wrong.type")).thenReturn("Image type is not allowed.");
@@ -132,18 +119,6 @@ class ImageServiceTest {
         assertFalse(Files.exists(testUploadDirPath.resolve(getImageIdFromUpload(mockImageFile))));
     }
 
-    @Test
-    void uploadImageWithScaling_validateImageFailsEmptyFile_throwsImageHandleException() throws IOException {
-        MultipartFile mockImageFile = new MockMultipartFile("image", TEST_IMAGE_NAME, "image/png", new byte[0]);
-        when(messageUtil.get("image.is.empty")).thenReturn("Image file is empty.");
-
-        ImageHandleException exception = assertThrows(ImageHandleException.class, () -> imageService.uploadImageWithScaling(mockImageFile, 100, 100));
-        assertEquals("Image file is empty.", exception.getErrors().get("image"));
-
-        verify(imageRepository, never()).save(any());
-        verify(messageUtil, times(1)).get("image.is.empty");
-        assertFalse(Files.exists(testUploadDirPath.resolve(getImageIdFromUpload(mockImageFile))));
-    }
 
     @Test
     void uploadImageWithScaling_validateImageFailsWrongType_throwsImageHandleException() throws IOException {

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
@@ -139,7 +139,7 @@ class ImageServiceTest {
     }
 
     @Test
-    void deleteImageById_shouldThrowException_whenIOExceptionOccurs() throws IOException {
+    void deleteImageById_shouldThrowException_whenIOExceptionOccurs(){
         String imageId = "test-image.jpg";
         Path filePath = Paths.get(TEST_UPLOAD_DIR, imageId);
 
@@ -149,8 +149,8 @@ class ImageServiceTest {
             filesMockedStatic.when(() -> Files.exists(filePath)).thenReturn(true);
             filesMockedStatic.when(() -> Files.deleteIfExists(filePath))
                     .thenThrow(new IOException("Access denied."));
-            
-            ImageHandleException exception = assertThrows(ImageHandleException.class, () -> {
+
+            assertThrows(ImageHandleException.class, () -> {
                 imageService.deleteImageById(imageId);
             });
         }

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageServiceTest.java
@@ -78,7 +78,6 @@ class ImageServiceTest {
             ImageUploadResponseDto responseDto = imageService.uploadImage(mockImageFile);
 
             assertNotNull(responseDto);
-            assertEquals(expectedImagePath, responseDto.getImagePath());
             assertEquals(expectedImageName, responseDto.getImageId());
 
             verify(imageRepository, times(1)).save(imageCaptor.capture());
@@ -119,45 +118,6 @@ class ImageServiceTest {
         assertFalse(Files.exists(testUploadDirPath.resolve(getImageIdFromUpload(mockImageFile))));
     }
 
-
-    @Test
-    void uploadImageWithScaling_validateImageFailsWrongType_throwsImageHandleException() throws IOException {
-        MultipartFile mockImageFile = new MockMultipartFile("image", "test-image.gif", "image/gif", TEST_IMAGE_DATA);
-        when(messageUtil.get("image.wrong.type")).thenReturn("Image type is not allowed.");
-
-        ImageHandleException exception = assertThrows(ImageHandleException.class, () -> imageService.uploadImageWithScaling(mockImageFile, 100, 100));
-        assertEquals("Image type is not allowed.", exception.getErrors().get("image"));
-
-        verify(imageRepository, never()).save(any());
-        verify(messageUtil, times(1)).get("image.wrong.type");
-        assertFalse(Files.exists(testUploadDirPath.resolve(getImageIdFromUpload(mockImageFile))));
-    }
-
-    @Test
-    void uploadImageWithScaling_imageIOReadFails_throwsImageHandleException() throws IOException {
-        MultipartFile mockImageFile = new MockMultipartFile("image", TEST_IMAGE_NAME, "image/png", TEST_IMAGE_DATA);
-        String fixedUuidString = "a1b2c3d4-e5f6-7890-1234-567890abcdef";
-        UUID fixedUuid = UUID.fromString(fixedUuidString);
-        when(messageUtil.get("image.upload.error")).thenReturn("Image upload failed.");
-        when(messageUtil.get("image.upload.read.error")).thenReturn("Failed to read image data.");
-
-        try (var mockStatic = mockStatic(UUID.class);
-             var mockImageIOStatic = mockStatic(ImageIO.class)) {
-            mockStatic.when(UUID::randomUUID).thenReturn(fixedUuid);
-            mockImageIOStatic.when(() -> ImageIO.read(any(java.io.InputStream.class))).thenReturn(null);
-
-            ImageHandleException exception = assertThrows(ImageHandleException.class,
-                    () -> imageService.uploadImageWithScaling(mockImageFile, 100, 100));
-
-            assertEquals("Image upload failed.Failed to read image data.", exception.getErrors().get("image"));
-
-            verify(imageRepository, never()).save(any());
-            verify(messageUtil, times(1)).get("image.upload.error");
-            verify(messageUtil, times(1)).get("image.upload.read.error");
-            assertFalse(Files.exists(Paths.get(TEST_UPLOAD_DIR + fixedUuidString + ".png")));
-        }
-    }
-
     @Test
     void deleteImageById_fileDeletesSuccessfully() throws IOException {
         String testUuid = "test-uuid.png";
@@ -180,51 +140,4 @@ class ImageServiceTest {
         assertFalse(result);
         assertFalse(Files.exists(filePath));
     }
-
-
-    // TODO: fix this mess
-//    @Test
-//    void uploadImageWithScaling_success() throws IOException {
-//        MultipartFile mockImageFile = new MockMultipartFile("image", TEST_IMAGE_NAME, "image/png", TEST_IMAGE_DATA);
-//        int targetWidth = 100;
-//        int targetHeight = 100;
-//        String fixedUuid = "a1b2c3d4-e5f6-7890-1234-567890abcdef";
-//        String expectedImageId = fixedUuid + ".png";
-//        String expectedImagePath = "/images/" + expectedImageId;
-//        Path expectedPath = Paths.get(TEST_UPLOAD_DIR, expectedImageId);
-//        BufferedImage mockOriginalImage = new BufferedImage(200, 200, BufferedImage.TYPE_INT_RGB);
-//        BufferedImage mockResizedImage = new BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_RGB);
-//        Image mockSavedImage = Image.builder().imageId(expectedImageId).build();
-//        ImageUploadResponseDto expectedResponseDto = ImageUploadResponseDto.builder()
-//                .imageId(expectedImageId)
-//                .imagePath(expectedImagePath)
-//                .build();
-//
-//        when(messageUtil.get("image.upload.error")).thenReturn("Image upload failed.");
-//        when(messageUtil.get("image.upload.write.error")).thenReturn("Failed to write resized image.");
-//        when(imageService.createImageUploadResponseDto(any(Image.class))).thenReturn(expectedResponseDto);
-//        when(imageRepository.save(any(Image.class))).thenReturn(mockSavedImage);
-//
-//        ImageUploadResponseDto actualResponseDto;
-//
-//        try (var mockStatic = mockStatic(UUID.class);
-//             var mockImageIOStatic = mockStatic(ImageIO.class)) {
-//            mockStatic.when(UUID::randomUUID).thenReturn(UUID.fromString(fixedUuid));
-//            mockImageIOStatic.when(() -> ImageIO.read(any(java.io.InputStream.class))).thenReturn(mockOriginalImage);
-//            mockImageIOStatic.when(() -> ImageIO.write(eq(mockResizedImage), eq("png"), eq(expectedPath.toFile()))).thenReturn(true);
-//
-//            // Act
-//            actualResponseDto = imageService.uploadImageWithScaling(mockImageFile, targetWidth, targetHeight);
-//        }
-//
-//        assertEquals(expectedResponseDto, actualResponseDto);
-//        verify(imageService, times(1)).validateImage(mockImageFile);
-//        verify(imageService, times(1)).resizeImage(mockOriginalImage, targetWidth, targetHeight);
-//        verify(imageRepository, times(1)).save(imageArgumentCaptor.capture());
-//        Image savedImage = imageArgumentCaptor.getValue();
-//        assertEquals(expectedImageId, savedImage.getImageId());
-//        verify(imageService, times(1)).createImageUploadResponseDto(savedImage);
-//        assertTrue(Files.exists(expectedPath));
-//        Files.deleteIfExists(expectedPath);
-//    }
 }

--- a/src/test/java/com/spaghetticodegang/trylater/image/ImageTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/ImageTest.java
@@ -8,16 +8,16 @@ public class ImageTest {
 
     @Test
     void testBuilderAndGetterSetter() {
-        String imageId = "testImageId";
+        String imgPath = "testImgPath";
 
         Image image = Image.builder()
-                .imageId(imageId)
+                .imgPath(imgPath)
                 .build();
 
         assertNotNull(image);
-        assertEquals(imageId, image.getImageId());
+        assertEquals(imgPath, image.getImgPath());
 
-        assertEquals(imageId, image.getImageId());
+        assertEquals(imgPath, image.getImgPath());
     }
 
     @Test
@@ -25,17 +25,17 @@ public class ImageTest {
         Image image = new Image();
 
         assertNotNull(image);
-        assertNull(image.getImageId());
+        assertNull(image.getImgPath());
     }
 
     @Test
     void testAllArgsConstructor() {
-        String imageId = "fullArgsConstructorId";
+        String imgPath = "fullArgsConstructorId";
 
-        Image image = new Image(imageId);
+        Image image = new Image(imgPath);
 
         assertNotNull(image);
-        assertEquals(imageId, image.getImageId());
+        assertEquals(imgPath, image.getImgPath());
     }
 
     @Test
@@ -43,6 +43,6 @@ public class ImageTest {
         Image image = Image.builder().build();
 
         assertNotNull(image);
-        assertNull(image.getImageId());
+        assertNull(image.getImgPath());
     }
 }

--- a/src/test/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDtoTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDtoTest.java
@@ -11,15 +11,15 @@ public class ImageUploadResponseDtoTest {
         String imageId = "uniqueImageId";
 
         ImageUploadResponseDto responseDto = ImageUploadResponseDto.builder()
-                .imageId(imageId)
+                .imagePath(imageId)
                 .build();
 
         assertNotNull(responseDto);
-        assertEquals(imageId, responseDto.getImageId());
+        assertEquals(imageId, responseDto.getImagePath());
 
         String newImageId = "anotherId";
-        responseDto.setImageId(newImageId);
-        assertEquals(newImageId, responseDto.getImageId());
+        responseDto.setImagePath(newImageId);
+        assertEquals(newImageId, responseDto.getImagePath());
     }
 
     @Test
@@ -27,6 +27,6 @@ public class ImageUploadResponseDtoTest {
         ImageUploadResponseDto responseDto = ImageUploadResponseDto.builder().build();
 
         assertNotNull(responseDto);
-        assertNull(responseDto.getImageId());
+        assertNull(responseDto.getImagePath());
     }
 }

--- a/src/test/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDtoTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDtoTest.java
@@ -8,18 +8,18 @@ public class ImageUploadResponseDtoTest {
 
     @Test
     void testBuilderAndGetterSetter() {
-        String imageId = "uniqueImageId";
+        String imgPath = "uniqueImgPath";
 
         ImageUploadResponseDto responseDto = ImageUploadResponseDto.builder()
-                .imagePath(imageId)
+                .imgPath(imgPath)
                 .build();
 
         assertNotNull(responseDto);
-        assertEquals(imageId, responseDto.getImagePath());
+        assertEquals(imgPath, responseDto.getImgPath());
 
-        String newImageId = "anotherId";
-        responseDto.setImagePath(newImageId);
-        assertEquals(newImageId, responseDto.getImagePath());
+        String newImgPath = "anotherId";
+        responseDto.setImgPath(newImgPath);
+        assertEquals(newImgPath, responseDto.getImgPath());
     }
 
     @Test
@@ -27,6 +27,6 @@ public class ImageUploadResponseDtoTest {
         ImageUploadResponseDto responseDto = ImageUploadResponseDto.builder().build();
 
         assertNotNull(responseDto);
-        assertNull(responseDto.getImagePath());
+        assertNull(responseDto.getImgPath());
     }
 }

--- a/src/test/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDtoTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/image/dto/ImageUploadResponseDtoTest.java
@@ -9,23 +9,17 @@ public class ImageUploadResponseDtoTest {
     @Test
     void testBuilderAndGetterSetter() {
         String imageId = "uniqueImageId";
-        String imagePath = "/path/to/image.png";
 
         ImageUploadResponseDto responseDto = ImageUploadResponseDto.builder()
                 .imageId(imageId)
-                .imagePath(imagePath)
                 .build();
 
         assertNotNull(responseDto);
         assertEquals(imageId, responseDto.getImageId());
-        assertEquals(imagePath, responseDto.getImagePath());
 
         String newImageId = "anotherId";
-        String newImagePath = "/new/path/image.jpg";
         responseDto.setImageId(newImageId);
-        responseDto.setImagePath(newImagePath);
         assertEquals(newImageId, responseDto.getImageId());
-        assertEquals(newImagePath, responseDto.getImagePath());
     }
 
     @Test
@@ -34,6 +28,5 @@ public class ImageUploadResponseDtoTest {
 
         assertNotNull(responseDto);
         assertNull(responseDto.getImageId());
-        assertNull(responseDto.getImagePath());
     }
 }

--- a/src/test/java/com/spaghetticodegang/trylater/recommendation/RecommendationControllerTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/recommendation/RecommendationControllerTest.java
@@ -142,7 +142,7 @@ class RecommendationControllerTest {
         when(recommendationService.updateRecommendationAssignmentStatus(any(User.class), any(Long.class), any(RecommendationAssignmentStatusRequestDto.class)))
                 .thenReturn(createRecommendationResponse());
 
-        mockMvc.perform(MockMvcRequestBuilders.patch("/api/recommendation/1")
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/recommendation/assignment/1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andExpect(status().isOk())
@@ -162,7 +162,7 @@ class RecommendationControllerTest {
         when(recommendationService.getAllRecommendationsByUserAndRecommendationStatus(any(User.class), any()))
                 .thenReturn(mockRecommendations);
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/recommendation")
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/recommendation/assignment")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -182,7 +182,7 @@ class RecommendationControllerTest {
         when(recommendationService.getAllRecommendationsByUserAndRecommendationStatus(any(User.class), eq(RecommendationAssignmentStatus.ACCEPTED)))
                 .thenReturn(mockRecommendations);
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/recommendation")
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/recommendation/assignment")
                         .param("status", "ACCEPTED")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -197,7 +197,7 @@ class RecommendationControllerTest {
         doNothing().when(recommendationService)
                 .deleteRecommendationAssignment(any(User.class), eq(recommendationId));
 
-        mockMvc.perform(delete("/api/recommendation/{id}", recommendationId)
+        mockMvc.perform(delete("/api/recommendation/assignment/{id}", recommendationId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent());
     }

--- a/src/test/java/com/spaghetticodegang/trylater/recommendation/RecommendationServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/recommendation/RecommendationServiceTest.java
@@ -1,6 +1,7 @@
 package com.spaghetticodegang.trylater.recommendation;
 
 import com.spaghetticodegang.trylater.contact.ContactService;
+import com.spaghetticodegang.trylater.image.ImageService;
 import com.spaghetticodegang.trylater.recommendation.assignment.RecommendationAssignmentService;
 import com.spaghetticodegang.trylater.recommendation.assignment.RecommendationAssignmentStatus;
 import com.spaghetticodegang.trylater.recommendation.assignment.dto.RecommendationAssignmentStatusRequestDto;
@@ -52,6 +53,9 @@ class RecommendationServiceTest {
 
     @Mock
     private ContactService contactService;
+
+    @Mock
+    private ImageService imageService;
 
     @Mock
     private MessageUtil messageUtil;
@@ -284,15 +288,51 @@ class RecommendationServiceTest {
     }
 
     @Test
-    void deleteRecommendationAssignment_recommendationNoLongerExists_deletesRecommendation() {
+    void deleteRecommendationAssignment_recommendationNoLongerExists_deletesRecommendationWithImage() {
+        Long recommendationId = 42L;
         User user = createUser(1L);
+
+        Recommendation recommendation = new Recommendation();
+        recommendation.setId(recommendationId);
+        recommendation.setImgPath("some/image/path.jpg");
+
         when(recommendationAssignmentService.existsRecommendationInRecommendationAssignment(recommendationId))
                 .thenReturn(false);
+        when(recommendationRepository.findById(recommendationId))
+                .thenReturn(Optional.of(recommendation));
 
         recommendationService.deleteRecommendationAssignment(user, recommendationId);
 
-        verify(recommendationAssignmentService).deleteRecommendationAssignmentByRecommendationId(user.getId(), recommendationId);
-        verify(recommendationAssignmentService).existsRecommendationInRecommendationAssignment(recommendationId);
+        verify(recommendationAssignmentService)
+                .deleteRecommendationAssignmentByRecommendationId(user.getId(), recommendationId);
+        verify(recommendationAssignmentService)
+                .existsRecommendationInRecommendationAssignment(recommendationId);
+        verify(recommendationRepository).findById(recommendationId);
+        verify(recommendationRepository).deleteById(recommendationId);
+        verify(imageService).deleteImageById("some/image/path.jpg");
+    }
+
+    @Test
+    void deleteRecommendationAssignment_recommendationNoLongerExists_deletesRecommendationWithoutAnImage() {
+        Long recommendationId = 42L;
+        User user = createUser(1L);
+
+        Recommendation recommendation = new Recommendation();
+        recommendation.setId(recommendationId);
+        recommendation.setImgPath(null);
+
+        when(recommendationAssignmentService.existsRecommendationInRecommendationAssignment(recommendationId))
+                .thenReturn(false);
+        when(recommendationRepository.findById(recommendationId))
+                .thenReturn(Optional.of(recommendation));
+
+        recommendationService.deleteRecommendationAssignment(user, recommendationId);
+
+        verify(recommendationAssignmentService)
+                .deleteRecommendationAssignmentByRecommendationId(user.getId(), recommendationId);
+        verify(recommendationAssignmentService)
+                .existsRecommendationInRecommendationAssignment(recommendationId);
+        verify(recommendationRepository).findById(recommendationId);
         verify(recommendationRepository).deleteById(recommendationId);
     }
 }

--- a/src/test/java/com/spaghetticodegang/trylater/recommendation/RecommendationServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/recommendation/RecommendationServiceTest.java
@@ -309,7 +309,7 @@ class RecommendationServiceTest {
                 .existsRecommendationInRecommendationAssignment(recommendationId);
         verify(recommendationRepository).findById(recommendationId);
         verify(recommendationRepository).deleteById(recommendationId);
-        verify(imageService).deleteImageById("some/image/path.jpg");
+        verify(imageService).deleteImageByImgPath("some/image/path.jpg");
     }
 
     @Test

--- a/src/test/java/com/spaghetticodegang/trylater/user/UserServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/user/UserServiceTest.java
@@ -362,14 +362,14 @@ class UserServiceTest {
         when(userRepository.findById(69L)).thenReturn(Optional.of(user));
         when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        when(imageService.deleteImageById("/assets/old.webp")).thenReturn(true);
+        when(imageService.deleteImageByImgPath("/assets/old.webp")).thenReturn(true);
 
         UserMeResponseDto response = userService.updateUserProfile(user, dto);
 
         assertEquals("/assets/cool.webp", user.getImgPath());
         assertEquals("/assets/cool.webp", response.getImgPath());
 
-        verify(imageService).deleteImageById("/assets/old.webp");
+        verify(imageService).deleteImageByImgPath("/assets/old.webp");
     }
 
     @Test
@@ -392,7 +392,7 @@ class UserServiceTest {
         assertEquals("/assets/cool.webp", user.getImgPath());
         assertEquals("/assets/cool.webp", response.getImgPath());
 
-        verify(imageService, never()).deleteImageById(anyString());
+        verify(imageService, never()).deleteImageByImgPath(anyString());
     }
 
 }

--- a/src/test/java/com/spaghetticodegang/trylater/user/UserServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/user/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.spaghetticodegang.trylater.user;
 
+import com.spaghetticodegang.trylater.image.ImageService;
 import com.spaghetticodegang.trylater.shared.exception.PasswordErrorException;
 import com.spaghetticodegang.trylater.shared.exception.ValidationException;
 import com.spaghetticodegang.trylater.shared.util.MessageUtil;
@@ -15,6 +16,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,6 +36,9 @@ class UserServiceTest {
 
     @InjectMocks
     private UserService userService;
+
+    @Mock
+    private ImageService imageService;
 
     @Test
     void shouldLoadUserByUsernameOrEmail() {
@@ -344,6 +349,33 @@ class UserServiceTest {
     @Test
     void shouldUpdateProfileWithoutPassword_whenOnlyImgPathChanges() {
         User user = User.builder()
+                .id(69L)
+                .userName("tester")
+                .email("test@example.com")
+                .password("encodedPass")
+                .imgPath("/assets/old.webp")
+                .build();
+
+        UserMeUpdateDto dto = new UserMeUpdateDto();
+        dto.setImgPath("/assets/cool.webp");
+
+        when(userRepository.findById(69L)).thenReturn(Optional.of(user));
+        when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        when(imageService.deleteImageById("/assets/old.webp")).thenReturn(true);
+
+        UserMeResponseDto response = userService.updateUserProfile(user, dto);
+
+        assertEquals("/assets/cool.webp", user.getImgPath());
+        assertEquals("/assets/cool.webp", response.getImgPath());
+
+        verify(imageService).deleteImageById("/assets/old.webp");
+    }
+
+    @Test
+    void shouldUpdateProfileWithoutPassword_whenOnlyImgPathChangesAndCurrentImgPathIsNull() {
+        User user = User.builder()
+                .id(69L)
                 .userName("tester")
                 .email("test@example.com")
                 .password("encodedPass")
@@ -352,12 +384,15 @@ class UserServiceTest {
         UserMeUpdateDto dto = new UserMeUpdateDto();
         dto.setImgPath("/assets/cool.webp");
 
+        when(userRepository.findById(69L)).thenReturn(Optional.of(user));
         when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         UserMeResponseDto response = userService.updateUserProfile(user, dto);
 
         assertEquals("/assets/cool.webp", user.getImgPath());
         assertEquals("/assets/cool.webp", response.getImgPath());
+
+        verify(imageService, never()).deleteImageById(anyString());
     }
 
 }

--- a/uml/class/Class_ImageUpload.puml
+++ b/uml/class/Class_ImageUpload.puml
@@ -3,7 +3,7 @@ skinparam classAttributeIconSize 0
 hide empty members
 
 class Image {
-    - id : String
+    - imgPath : String
     + constructor()
     + getter()
     + setter()
@@ -16,16 +16,13 @@ interface ImageRepository {
 class ImageService {
     - imageRepository : ImageRepository
     + uploadImage(imageFile : MultipartFile)
-    + uploadImageWithScaling(imageFile : MultipartFile, int : targetWidth, int : targetHeight)
-    + deleteImageById(imageId : String)
+    + deleteImageByImgPath(imgPath : String)
     - getImageType(String : imageName)
-    - resizeImage(BufferedImage : originalImage, int : targetWidth, int : targetHeight)
     - validateImage(imageFile : MultipartFile)
 }
 class ImageController {
     - imageService : ImageService
     + POST /api/images() <<secured>>
-    + POST /api/images/scaling() <<secured>>
     + DELETE /api/images() <<secured>>
 }
 


### PR DESCRIPTION
1.) Hab alle deine Anmerkungen aus dem ersten Merge Request für den Image Uploader umgesetzt
2.) Wenn Empfehlung gelöscht wird (also nirgends mehr zugeordnet) wird auch, falls vorhanden das zugehörige Bild gelöscht (DB + Dateisystem)
3.) Wenn Nutzer sein Profilbild durch ein neues ersetzen möchte, wird das Alte, auch falls hier vorhanden, gelöscht (DB + Dateisystem)
4.) Da das allgemeine Löschen eines Nutzerprofils noch nicht umgesetzt wurde, konnte ich da noch nichts einbauen
5.) Test sind aktualisiert und ein paar Bugs sind gefixt
<3 