### PR TITLE
Fix recommendation assignment patch 106

### DIFF
--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationController.java
@@ -41,13 +41,13 @@ public class RecommendationController {
      * Handles a recommendation assignment status update request by delegating to the service layer.
      *
      * @param me                             the currently authenticated user (requester)
-     * @param recommendationAssignmentId     the ID of the recommendation assignment to update
+     * @param recommendationId     the ID of the recommendation that assignment to update
      * @param recommendationAssignmentStatus the recommendation assignment status
      * @return the created recommendation as a response DTO
      */
     @PatchMapping("/{id}")
-    public ResponseEntity<RecommendationResponseDto> updateRecommendationAssignmentStatus(@AuthenticationPrincipal User me, @PathVariable("id") Long recommendationAssignmentId, @RequestBody @Valid RecommendationAssignmentStatusRequestDto recommendationAssignmentStatus) {
-        RecommendationResponseDto recommendationResponseDto = recommendationService.updateRecommendationAssignmentStatus(me, recommendationAssignmentId, recommendationAssignmentStatus);
+    public ResponseEntity<RecommendationResponseDto> updateRecommendationAssignmentStatus(@AuthenticationPrincipal User me, @PathVariable("id") Long recommendationId, @RequestBody @Valid RecommendationAssignmentStatusRequestDto recommendationAssignmentStatus) {
+        RecommendationResponseDto recommendationResponseDto = recommendationService.updateRecommendationAssignmentStatus(me, recommendationId, recommendationAssignmentStatus);
         return ResponseEntity.ok(recommendationResponseDto);
     }
 

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationService.java
@@ -108,14 +108,14 @@ public class RecommendationService {
     /**
      * Updates the status of a {@link RecommendationAssignment} for the currently authenticated user.
      *
-     * @param me                         the currently authenticated {@link User}
-     * @param recommendationAssignmentId the ID of the {@link RecommendationAssignment} to update
-     * @param request                    the {@link RecommendationAssignmentStatusRequestDto} containing the new status
+     * @param me               the currently authenticated {@link User}
+     * @param recommendationId the ID of the {@link Recommendation} to update the assignment status
+     * @param request          the {@link RecommendationAssignmentStatusRequestDto} containing the new status
      * @return a response DTO representing the recommendation
      * @throws RecommendationNotFoundException if there is no recommendation with requested ID
      */
-    public RecommendationResponseDto updateRecommendationAssignmentStatus(User me, Long recommendationAssignmentId, RecommendationAssignmentStatusRequestDto request) {
-        Long recommendationId = recommendationAssignmentService.updateRecommendationAssignmentStatus(me, recommendationAssignmentId, request);
+    public RecommendationResponseDto updateRecommendationAssignmentStatus(User me, Long recommendationId, RecommendationAssignmentStatusRequestDto request) {
+        recommendationAssignmentService.updateRecommendationAssignmentStatus(me, recommendationId, request);
         Recommendation recommendation = getRecommendationById(recommendationId);
 
         return createRecommendationResponseDto(recommendation);
@@ -166,7 +166,8 @@ public class RecommendationService {
 
     /**
      * Lists all assigned recommendation with a specific status for a given user.
-     * @param me the currently authenticated user
+     *
+     * @param me                             the currently authenticated user
      * @param recommendationAssignmentStatus status of the assigment
      * @return a list of response DTOs representing the recommendations
      */

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentService.java
@@ -46,14 +46,13 @@ public class RecommendationAssignmentService {
      * Performs validation and updates the recommendation assignment's status, including setting the acceptance date if applicable.
      *
      * @param me                                       the currently authenticated user
-     * @param recommendationAssignmentId               the ID of the recommendation assignment whose status is to be updated
+     * @param recommendationId                         the ID of the recommendation whose assignment status is to be updated
      * @param recommendationAssignmentStatusRequestDto the DTO containing the new recommendation assignment status
-     * @return a response DTO representing the updated recommendation assignment
      * @throws ValidationException if the status change is invalid
      */
-    public Long updateRecommendationAssignmentStatus(User me, Long recommendationAssignmentId, RecommendationAssignmentStatusRequestDto recommendationAssignmentStatusRequestDto) {
+    public void updateRecommendationAssignmentStatus(User me, Long recommendationId, RecommendationAssignmentStatusRequestDto recommendationAssignmentStatusRequestDto) {
         final RecommendationAssignmentStatus recommendationAssignmentStatus = recommendationAssignmentStatusRequestDto.getRecommendationAssignmentStatus();
-        final RecommendationAssignment recommendationAssignment = getRecommendationAssignmentById(recommendationAssignmentId);
+        final RecommendationAssignment recommendationAssignment = getRecommendationAssignmentByUserIdAndRecommendationId(me.getId(), recommendationId);
 
         if (!Objects.equals(recommendationAssignment.getReceiver().getId(), me.getId())) {
             throw new ValidationException(Map.of("recommendationAssignment", messageUtil.get("recommendation.assignment.error.user.not.allowed")));
@@ -69,8 +68,6 @@ public class RecommendationAssignmentService {
 
         recommendationAssignment.setRecommendationAssignmentStatus(recommendationAssignmentStatus);
         recommendationAssignmentRepository.save(recommendationAssignment);
-
-        return recommendationAssignment.getId();
     }
 
     /**

--- a/src/test/java/com/spaghetticodegang/trylater/recommendation/RecommendationServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/recommendation/RecommendationServiceTest.java
@@ -215,24 +215,23 @@ class RecommendationServiceTest {
     @Test
     void testUpdateRecommendationAssignmentStatus_recommendationNotFound() {
         User me = new User();
-        Long recommendationAssignmentId = 1L;
         Long recommendationId = 10L;
         RecommendationAssignmentStatusRequestDto requestDto = new RecommendationAssignmentStatusRequestDto();
 
-        Mockito.when(recommendationAssignmentService.updateRecommendationAssignmentStatus(me, recommendationAssignmentId, requestDto))
-                .thenReturn(recommendationId);
+        Mockito.doNothing().when(recommendationAssignmentService)
+                .updateRecommendationAssignmentStatus(me, recommendationId, requestDto);
+
         Mockito.when(recommendationRepository.findById(recommendationId))
                 .thenReturn(Optional.empty());
 
         Assertions.assertThrows(RecommendationNotFoundException.class, () -> {
-            recommendationService.updateRecommendationAssignmentStatus(me, recommendationAssignmentId, requestDto);
+            recommendationService.updateRecommendationAssignmentStatus(me, recommendationId, requestDto);
         });
     }
 
     @Test
     void shouldUpdateRecommendationAssignmentStatusSuccessfully() {
         User user = createUser(1L);
-        Long recommendationAssignmentId = 100L;
         Long recommendationId = 200L;
 
         RecommendationAssignmentStatusRequestDto requestDto = new RecommendationAssignmentStatusRequestDto();
@@ -247,12 +246,11 @@ class RecommendationServiceTest {
                 .category(createCategory(CategoryType.MEDIA))
                 .build();
 
-        when(recommendationAssignmentService.updateRecommendationAssignmentStatus(user, recommendationAssignmentId, requestDto))
-                .thenReturn(recommendationId);
+        doNothing().when(recommendationAssignmentService).updateRecommendationAssignmentStatus(user, recommendationId, requestDto);
         when(recommendationRepository.findById(recommendationId))
                 .thenReturn(Optional.of(recommendation));
 
-        RecommendationResponseDto response = recommendationService.updateRecommendationAssignmentStatus(user, recommendationAssignmentId, requestDto);
+        RecommendationResponseDto response = recommendationService.updateRecommendationAssignmentStatus(user, recommendationId, requestDto);
 
         assertNotNull(response);
         assertEquals(recommendation.getId(), response.getId());
@@ -262,7 +260,7 @@ class RecommendationServiceTest {
         assertEquals(recommendation.getImgPath(), response.getImgPath());
         assertEquals(recommendation.getCategory().getCategoryType(), response.getCategory());
 
-        verify(recommendationAssignmentService).updateRecommendationAssignmentStatus(user, recommendationAssignmentId, requestDto);
+        verify(recommendationAssignmentService).updateRecommendationAssignmentStatus(user, recommendationId, requestDto);
         verify(recommendationRepository).findById(recommendationId);
     }
 

--- a/src/test/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentServiceTest.java
@@ -170,7 +170,7 @@ class RecommendationAssignmentServiceTest {
         when(recommendationAssignmentRepository.findById(recommendationAssignmentId)).thenReturn(Optional.of(existingAssignment));
         when(recommendationAssignmentRepository.save(any(RecommendationAssignment.class))).thenReturn(existingAssignment);
 
-        Long updatedId = recommendationAssignmentService.updateRecommendationAssignmentStatus(authenticatedUser, recommendationAssignmentId, requestDto);
+        recommendationAssignmentService.updateRecommendationAssignmentStatus(authenticatedUser, recommendationId, requestDto);
 
         assertEquals(recommendationAssignmentId, updatedId);
         assertEquals(RecommendationAssignmentStatus.ACCEPTED, existingAssignment.getRecommendationAssignmentStatus());

--- a/src/test/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentServiceTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentServiceTest.java
@@ -104,15 +104,14 @@ class RecommendationAssignmentServiceTest {
         existingAssignment.setReceiver(differentUser);
         requestDto.setRecommendationAssignmentStatus(RecommendationAssignmentStatus.ACCEPTED);
 
-        when(recommendationAssignmentRepository.findById(recommendationAssignmentId)).thenReturn(Optional.of(existingAssignment));
+        when(recommendationAssignmentRepository.findRecommendationAssignmentByUserIdAndRecommendationId(authenticatedUser.getId(), recommendationId)).thenReturn(existingAssignment);
         when(messageUtil.get("recommendation.assignment.error.user.not.allowed")).thenReturn("User not allowed to update this assignment.");
 
         ValidationException exception = assertThrows(ValidationException.class, () ->
-                recommendationAssignmentService.updateRecommendationAssignmentStatus(authenticatedUser, recommendationAssignmentId, requestDto)
+                recommendationAssignmentService.updateRecommendationAssignmentStatus(authenticatedUser, recommendationId, requestDto)
         );
 
         assertEquals("User not allowed to update this assignment.", exception.getErrors().get("recommendationAssignment"));
-        verify(recommendationAssignmentRepository, times(1)).findById(recommendationAssignmentId);
         verify(recommendationAssignmentRepository, never()).save(any());
     }
 
@@ -120,15 +119,14 @@ class RecommendationAssignmentServiceTest {
     void updateRecommendationAssignmentStatus_cannotRevertToSentStatus() {
         requestDto.setRecommendationAssignmentStatus(RecommendationAssignmentStatus.SENT);
 
-        when(recommendationAssignmentRepository.findById(recommendationAssignmentId)).thenReturn(Optional.of(existingAssignment));
+        when(recommendationAssignmentRepository.findRecommendationAssignmentByUserIdAndRecommendationId(authenticatedUser.getId(), recommendationId)).thenReturn(existingAssignment);
         when(messageUtil.get("recommendation.assignment.error.status.revert.to.sent")).thenReturn("Cannot revert status to SENT.");
 
         ValidationException exception = assertThrows(ValidationException.class, () ->
-                recommendationAssignmentService.updateRecommendationAssignmentStatus(authenticatedUser, recommendationAssignmentId, requestDto)
+                recommendationAssignmentService.updateRecommendationAssignmentStatus(authenticatedUser, recommendationId, requestDto)
         );
 
         assertEquals("Cannot revert status to SENT.", exception.getErrors().get("recommendationAssignmentStatus"));
-        verify(recommendationAssignmentRepository, times(1)).findById(recommendationAssignmentId);
         verify(recommendationAssignmentRepository, never()).save(any());
     }
 
@@ -156,25 +154,28 @@ class RecommendationAssignmentServiceTest {
     @Test
     void updateRecommendationAssignmentStatus_shouldSetAcceptedAtWhenStatusIsAccepted() {
         User authenticatedUser = User.builder().id(1L).build();
-        Long recommendationAssignmentId = 42L;
+        Long recommendationId = 100L;
+
+        Recommendation recommendation = Recommendation.builder().id(recommendationId).build();
 
         RecommendationAssignment existingAssignment = RecommendationAssignment.builder()
-                .id(recommendationAssignmentId)
+                .id(42L)
                 .receiver(authenticatedUser)
                 .recommendationAssignmentStatus(RecommendationAssignmentStatus.SENT)
+                .recommendation(recommendation)
                 .build();
 
         RecommendationAssignmentStatusRequestDto requestDto = new RecommendationAssignmentStatusRequestDto();
         requestDto.setRecommendationAssignmentStatus(RecommendationAssignmentStatus.ACCEPTED);
 
-        when(recommendationAssignmentRepository.findById(recommendationAssignmentId)).thenReturn(Optional.of(existingAssignment));
-        when(recommendationAssignmentRepository.save(any(RecommendationAssignment.class))).thenReturn(existingAssignment);
+        when(recommendationAssignmentService.getRecommendationAssignmentByUserIdAndRecommendationId(authenticatedUser.getId(), recommendationId))
+                .thenReturn(existingAssignment);
+        when(recommendationAssignmentRepository.save(any())).thenReturn(existingAssignment);
 
         recommendationAssignmentService.updateRecommendationAssignmentStatus(authenticatedUser, recommendationId, requestDto);
 
-        assertEquals(recommendationAssignmentId, updatedId);
         assertEquals(RecommendationAssignmentStatus.ACCEPTED, existingAssignment.getRecommendationAssignmentStatus());
-        assertNotNull(existingAssignment.getAcceptedAt(), "acceptedAt should be set when status is ACCEPTED");
+        assertNotNull(existingAssignment.getAcceptedAt());
 
         ArgumentCaptor<RecommendationAssignment> argumentCaptor = ArgumentCaptor.forClass(RecommendationAssignment.class);
         verify(recommendationAssignmentRepository).save(argumentCaptor.capture());
@@ -182,9 +183,8 @@ class RecommendationAssignmentServiceTest {
         RecommendationAssignment savedAssignment = argumentCaptor.getValue();
         assertEquals(RecommendationAssignmentStatus.ACCEPTED, savedAssignment.getRecommendationAssignmentStatus());
         assertNotNull(savedAssignment.getAcceptedAt());
-
-        verify(recommendationAssignmentRepository).findById(recommendationAssignmentId);
     }
+
 
     @Test
     void shouldReturnRecommendationsByUserAndStatus() {


### PR DESCRIPTION
das assignment update nimmt nun die recommendationId und nicht die die ID des assignments für den Status-Update 