### PR TITLE
Benutzer loeschen 46

### DIFF
--- a/src/main/java/com/spaghetticodegang/trylater/contact/ContactRepository.java
+++ b/src/main/java/com/spaghetticodegang/trylater/contact/ContactRepository.java
@@ -72,6 +72,11 @@ public interface ContactRepository extends JpaRepository<Contact, Long> {
      */
     List<Contact> findByBlockedByIdAndContactStatus(Long blockedById, ContactStatus contactStatus);
 
+    /**
+     * IN case of a user is deleted, all his contacts will be deleted
+     *
+     * @param userId the ID of the user that should be deleted
+     */
     @Transactional
     @Modifying
     @Query("""

--- a/src/main/java/com/spaghetticodegang/trylater/contact/ContactRepository.java
+++ b/src/main/java/com/spaghetticodegang/trylater/contact/ContactRepository.java
@@ -1,7 +1,9 @@
 package com.spaghetticodegang.trylater.contact;
 
 import com.spaghetticodegang.trylater.contact.enums.ContactStatus;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -69,4 +71,11 @@ public interface ContactRepository extends JpaRepository<Contact, Long> {
      * @return a list of {@link Contact} entities
      */
     List<Contact> findByBlockedByIdAndContactStatus(Long blockedById, ContactStatus contactStatus);
+
+    @Transactional
+    @Modifying
+    @Query("""
+            DELETE FROM Contact c WHERE c.receiver.id = :userId OR c.requester.id = :userId
+            """)
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/spaghetticodegang/trylater/contact/ContactRepository.java
+++ b/src/main/java/com/spaghetticodegang/trylater/contact/ContactRepository.java
@@ -77,5 +77,5 @@ public interface ContactRepository extends JpaRepository<Contact, Long> {
     @Query("""
             DELETE FROM Contact c WHERE c.receiver.id = :userId OR c.requester.id = :userId
             """)
-    void deleteByUserId(Long userId);
+    void deleteContactsByUserId(Long userId);
 }

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/Recommendation.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/Recommendation.java
@@ -42,8 +42,8 @@ public class Recommendation {
     @Column(nullable = false)
     private int rating;
 
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    @JoinColumn(name = "creator_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id")
     private User creator;
 
     @Column(nullable = false)

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationRepository.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationRepository.java
@@ -10,10 +10,15 @@ import org.springframework.data.repository.CrudRepository;
  */
 public interface RecommendationRepository extends CrudRepository<Recommendation, Long> {
 
+    /**
+     * In case of a user is deleted, updates the creator to null
+     *
+     * @param userId the ID of the user, that is set to null
+     */
     @Transactional
     @Modifying
     @Query("""
                 UPDATE Recommendation r SET r.creator = null WHERE r.creator.id = :userId
             """)
-    void updateCreator(Long userId);
+    void updateCreatorToNull(Long userId);
 }

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationRepository.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationRepository.java
@@ -1,8 +1,19 @@
 package com.spaghetticodegang.trylater.recommendation;
 
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 /**
  * Repository interface for accessing and managing recommendation entities in the database.
  */
-public interface RecommendationRepository extends CrudRepository<Recommendation, Long> {}
+public interface RecommendationRepository extends CrudRepository<Recommendation, Long> {
+
+    @Transactional
+    @Modifying
+    @Query("""
+                UPDATE Recommendation r SET r.creator = null WHERE r.creator.id = :userId
+            """)
+    void updateCreator(Long userId);
+}

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationRepository.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/RecommendationRepository.java
@@ -1,6 +1,7 @@
 package com.spaghetticodegang.trylater.recommendation;
 
 import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -8,7 +9,7 @@ import org.springframework.data.repository.CrudRepository;
 /**
  * Repository interface for accessing and managing recommendation entities in the database.
  */
-public interface RecommendationRepository extends CrudRepository<Recommendation, Long> {
+public interface RecommendationRepository extends JpaRepository<Recommendation, Long> {
 
     /**
      * In case of a user is deleted, updates the creator to null

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentRepository.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentRepository.java
@@ -17,7 +17,7 @@ public interface RecommendationAssignmentRepository extends JpaRepository<Recomm
     /**
      * Finds all assigned recommendations for a given user with a specific status.
      *
-     * @param id the user ID
+     * @param id                             the user ID
      * @param recommendationAssignmentStatus the assignment status
      * @return a list of recommendation entities or an empty list
      */
@@ -26,10 +26,10 @@ public interface RecommendationAssignmentRepository extends JpaRepository<Recomm
             """)
     List<Recommendation> findRecommendationsByUserIdAndRecommendationAssignmentStatus(Long id, RecommendationAssignmentStatus recommendationAssignmentStatus);
 
-    /**       
+    /**
      * Finds the recommendation assignment for the given user ID and recommendation ID.
      *
-     * @param userId the given user ID
+     * @param userId           the given user ID
      * @param recommendationId the given recommendation ID
      * @return A {@link RecommendationAssignment} Entity
      */
@@ -37,6 +37,18 @@ public interface RecommendationAssignmentRepository extends JpaRepository<Recomm
             SELECT r FROM RecommendationAssignment r WHERE r.receiver.id = :userId AND r.recommendation.id = :recommendationId
             """)
     RecommendationAssignment findRecommendationAssignmentByUserIdAndRecommendationId(Long userId, Long recommendationId);
+
+    /**
+     * Finds all recommendation assignments for the given user ID.
+     *
+     * @param userId the given user ID
+     * @return A {@link RecommendationAssignment} Entity
+     */
+    @Query("""
+            SELECT r FROM RecommendationAssignment r WHERE r.receiver.id = :userId
+            """)
+    List<RecommendationAssignment> findAllRecommendationAssignmentByUserId(Long userId);
+
 
     /**
      * Checks if a recommendation assignment for a given recommendation ID exists.
@@ -52,6 +64,11 @@ public interface RecommendationAssignmentRepository extends JpaRepository<Recomm
     boolean existsRecommendationAssignmentByRecommendationId(Long recommendationId);
 
 
+    /**
+     * Deletes all assignment for the given user.
+     *
+     * @param userId the ID for the user that assignments should be deleting
+     */
     @Transactional
     @Modifying
     @Query("""

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentRepository.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentRepository.java
@@ -1,7 +1,9 @@
 package com.spaghetticodegang.trylater.recommendation.assignment;
 
 import com.spaghetticodegang.trylater.recommendation.Recommendation;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -48,4 +50,12 @@ public interface RecommendationAssignmentRepository extends JpaRepository<Recomm
             WHERE r.recommendation.id = :recommendationId
             """)
     boolean existsRecommendationAssignmentByRecommendationId(Long recommendationId);
+
+
+    @Transactional
+    @Modifying
+    @Query("""
+            DELETE FROM RecommendationAssignment r WHERE r.receiver.id = :userId
+            """)
+    void deleteRecommendationAssignmentsByUserId(Long userId);
 }

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserController.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserController.java
@@ -1,9 +1,6 @@
 package com.spaghetticodegang.trylater.user;
 
-import com.spaghetticodegang.trylater.user.dto.UserMeResponseDto;
-import com.spaghetticodegang.trylater.user.dto.UserMeRegistrationDto;
-import com.spaghetticodegang.trylater.user.dto.UserMeUpdateDto;
-import com.spaghetticodegang.trylater.user.dto.UserResponseDto;
+import com.spaghetticodegang.trylater.user.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -68,5 +65,11 @@ public class UserController {
     public ResponseEntity<UserMeResponseDto> updateUserProfile(@AuthenticationPrincipal User me, @RequestBody @Valid UserMeUpdateDto userMeUpdateDto) {
         UserMeResponseDto userMeResponseDto = userService.updateUserProfile(me, userMeUpdateDto);
         return ResponseEntity.ok(userMeResponseDto);
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal User me, @RequestBody @Valid UserMeDeleteDto userMeDeleteDto) {
+        userService.deleteUserProfile(me, userMeDeleteDto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -240,7 +240,5 @@ public class UserService implements UserDetailsService {
 
         recommendationRepository.updateCreatorToNull(me.getId());
         userRepository.delete(me);
-
-        //ALTER TABLE recommendations ALTER COLUMN creator_id DROP NOT NULL
     }
 }

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -2,6 +2,7 @@ package com.spaghetticodegang.trylater.user;
 
 import com.spaghetticodegang.trylater.contact.ContactRepository;
 import com.spaghetticodegang.trylater.image.ImageService;
+import com.spaghetticodegang.trylater.recommendation.assignment.RecommendationAssignmentRepository;
 import com.spaghetticodegang.trylater.shared.exception.PasswordErrorException;
 import com.spaghetticodegang.trylater.shared.exception.ValidationException;
 import com.spaghetticodegang.trylater.shared.util.MessageUtil;
@@ -29,6 +30,7 @@ public class UserService implements UserDetailsService {
     private final PasswordEncoder passwordEncoder;
     private final MessageUtil messageUtil;
     private final ContactRepository contactRepository;
+    private final RecommendationAssignmentRepository recommendationAssignmentRepository;
 
     /**
      * Loads a user by username or email for authentication.
@@ -206,6 +208,11 @@ public class UserService implements UserDetailsService {
         return createUserMeResponseDto(me);
     }
 
+    /**
+     * Deletes an user profile and manages the handling for deleting the contacts and assignments for that user.
+     * @param me user that should delete
+     * @param userMeDeleteDto the dto for the request
+     */
     public void deleteUserProfile(User me, UserMeDeleteDto userMeDeleteDto) {
         if (!passwordEncoder.matches(userMeDeleteDto.getPassword(), me.getPassword())) {
             throw new PasswordErrorException("auth.invalid.password");
@@ -214,8 +221,8 @@ public class UserService implements UserDetailsService {
             imageService.deleteImageByImgPath(me.getImgPath());
         }
 
-        contactRepository.deleteByUserId(me.getId());
-        //delete assignments
+        contactRepository.deleteContactsByUserId(me.getId());
+        recommendationAssignmentRepository.deleteRecommendationAssignmentsByUserId(me.getId());
         //is user creator ? make as prepToDelete : deleteUser
         // in delete recommendation 
         //userRepository.delete(me);

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -2,6 +2,7 @@ package com.spaghetticodegang.trylater.user;
 
 import com.spaghetticodegang.trylater.contact.ContactRepository;
 import com.spaghetticodegang.trylater.image.ImageService;
+import com.spaghetticodegang.trylater.recommendation.RecommendationRepository;
 import com.spaghetticodegang.trylater.recommendation.assignment.RecommendationAssignmentRepository;
 import com.spaghetticodegang.trylater.shared.exception.PasswordErrorException;
 import com.spaghetticodegang.trylater.shared.exception.ValidationException;
@@ -31,6 +32,7 @@ public class UserService implements UserDetailsService {
     private final MessageUtil messageUtil;
     private final ContactRepository contactRepository;
     private final RecommendationAssignmentRepository recommendationAssignmentRepository;
+    private final RecommendationRepository recommendationRepository;
 
     /**
      * Loads a user by username or email for authentication.
@@ -145,11 +147,11 @@ public class UserService implements UserDetailsService {
      * Updates the user profile with the new given entries.
      * Authentication required for username, email and new password.
      *
-     * @param me user entity that profile should be updated
+     * @param me              user entity that profile should be updated
      * @param userMeUpdateDto request dto with the new data
      * @return a full response DTO for the currently authenticated user
      * @throws PasswordErrorException if password input for authentication is incorrect
-     * @throws ValidationException if username or email already exists
+     * @throws ValidationException    if username or email already exists
      */
     public UserMeResponseDto updateUserProfile(User me, UserMeUpdateDto userMeUpdateDto) {
         final Map<String, String> errors = new HashMap<>();
@@ -210,7 +212,8 @@ public class UserService implements UserDetailsService {
 
     /**
      * Deletes an user profile and manages the handling for deleting the contacts and assignments for that user.
-     * @param me user that should delete
+     *
+     * @param me              user that should delete
      * @param userMeDeleteDto the dto for the request
      */
     public void deleteUserProfile(User me, UserMeDeleteDto userMeDeleteDto) {
@@ -223,8 +226,9 @@ public class UserService implements UserDetailsService {
 
         contactRepository.deleteContactsByUserId(me.getId());
         recommendationAssignmentRepository.deleteRecommendationAssignmentsByUserId(me.getId());
-        //is user creator ? make as prepToDelete : deleteUser
-        // in delete recommendation 
-        //userRepository.delete(me);
+        recommendationRepository.updateCreator(me.getId());
+        userRepository.delete(me);
+
+        //ALTER TABLE recommendations ALTER COLUMN creator_id DROP NOT NULL
     }
 }

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -1,13 +1,12 @@
 package com.spaghetticodegang.trylater.user;
 
+import com.spaghetticodegang.trylater.contact.ContactRepository;
+import com.spaghetticodegang.trylater.contact.ContactService;
 import com.spaghetticodegang.trylater.image.ImageService;
 import com.spaghetticodegang.trylater.shared.exception.PasswordErrorException;
 import com.spaghetticodegang.trylater.shared.exception.ValidationException;
 import com.spaghetticodegang.trylater.shared.util.MessageUtil;
-import com.spaghetticodegang.trylater.user.dto.UserMeRegistrationDto;
-import com.spaghetticodegang.trylater.user.dto.UserMeResponseDto;
-import com.spaghetticodegang.trylater.user.dto.UserMeUpdateDto;
-import com.spaghetticodegang.trylater.user.dto.UserResponseDto;
+import com.spaghetticodegang.trylater.user.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -30,6 +29,7 @@ public class UserService implements UserDetailsService {
     private final ImageService imageService;
     private final PasswordEncoder passwordEncoder;
     private final MessageUtil messageUtil;
+    private final ContactRepository contactRepository;
 
     /**
      * Loads a user by username or email for authentication.
@@ -205,5 +205,20 @@ public class UserService implements UserDetailsService {
         userRepository.save(me);
 
         return createUserMeResponseDto(me);
+    }
+
+    public void deleteUserProfile(User me, UserMeDeleteDto userMeDeleteDto) {
+        if (!passwordEncoder.matches(userMeDeleteDto.getPassword(), me.getPassword())) {
+            throw new PasswordErrorException("auth.invalid.password");
+        }
+        if (me.getImgPath() != null) {
+            imageService.deleteImageByImgPath(me.getImgPath());
+        }
+
+        contactRepository.deleteByUserId(me.getId());
+        //delete assignments
+        //is user creator ? make as prepToDelete : deleteUser
+        // in delete recommendation 
+        //userRepository.delete(me);
     }
 }

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -234,6 +234,9 @@ public class UserService implements UserDetailsService {
         allAssignments.forEach(assignment -> {
             Long recommendationId = assignment.getRecommendation().getId();
             if (!recommendationAssignmentRepository.existsRecommendationAssignmentByRecommendationId(recommendationId)) {
+                if (assignment.getRecommendation().getImgPath() != null) {
+                    imageService.deleteImageByImgPath(assignment.getRecommendation().getImgPath());
+                }
                 recommendationRepository.deleteById(recommendationId);
             }
         });

--- a/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/UserService.java
@@ -1,7 +1,6 @@
 package com.spaghetticodegang.trylater.user;
 
 import com.spaghetticodegang.trylater.contact.ContactRepository;
-import com.spaghetticodegang.trylater.contact.ContactService;
 import com.spaghetticodegang.trylater.image.ImageService;
 import com.spaghetticodegang.trylater.shared.exception.PasswordErrorException;
 import com.spaghetticodegang.trylater.shared.exception.ValidationException;

--- a/src/main/java/com/spaghetticodegang/trylater/user/dto/UserMeDeleteDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/user/dto/UserMeDeleteDto.java
@@ -1,0 +1,14 @@
+package com.spaghetticodegang.trylater.user.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserMeDeleteDto {
+
+    @Size(min = 6, message = "{user.password.size}")
+    private String password;
+
+}

--- a/src/test/java/com/spaghetticodegang/trylater/user/UserControllerTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/user/UserControllerTest.java
@@ -2,10 +2,7 @@ package com.spaghetticodegang.trylater.user;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spaghetticodegang.trylater.shared.util.MessageUtil;
-import com.spaghetticodegang.trylater.user.dto.UserMeRegistrationDto;
-import com.spaghetticodegang.trylater.user.dto.UserMeResponseDto;
-import com.spaghetticodegang.trylater.user.dto.UserMeUpdateDto;
-import com.spaghetticodegang.trylater.user.dto.UserResponseDto;
+import com.spaghetticodegang.trylater.user.dto.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -155,6 +152,17 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.displayName").value("Updated Tester"))
                 .andExpect(jsonPath("$.email").value("updated@example.com"))
                 .andExpect(jsonPath("$.imgPath").value("/assets/updated.webp"));
+    }
+
+    @Test
+    void shouldReturn204_whenUserIsDeletedSuccessfully() throws Exception {
+        UserMeDeleteDto deleteDto = new UserMeDeleteDto();
+        deleteDto.setPassword("validPassword123");
+
+        mockMvc.perform(delete("/api/user/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(deleteDto)))
+                .andExpect(status().isNoContent());
     }
 
 }

--- a/src/test/java/com/spaghetticodegang/trylater/user/dto/UserMeDeleteDtoTest.java
+++ b/src/test/java/com/spaghetticodegang/trylater/user/dto/UserMeDeleteDtoTest.java
@@ -1,0 +1,56 @@
+package com.spaghetticodegang.trylater.user.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserMeDeleteDtoTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    void shouldNotHaveViolations_whenPasswordIsValid() {
+        UserMeDeleteDto dto = new UserMeDeleteDto();
+        dto.setPassword("secure123");
+
+        Set<ConstraintViolation<UserMeDeleteDto>> violations = validator.validate(dto);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void shouldHaveViolation_whenPasswordTooShort() {
+        UserMeDeleteDto dto = new UserMeDeleteDto();
+        dto.setPassword("123"); // zu kurz
+
+        Set<ConstraintViolation<UserMeDeleteDto>> violations = validator.validate(dto);
+
+        assertThat(violations).hasSize(1);
+        ConstraintViolation<UserMeDeleteDto> violation = violations.iterator().next();
+        assertThat(violation.getPropertyPath().toString()).isEqualTo("password");
+        assertThat(violation.getMessage()).isEqualTo("{user.password.size}");
+    }
+
+    @Test
+    void shouldHaveViolation_whenPasswordIsNull() {
+        UserMeDeleteDto dto = new UserMeDeleteDto();
+        dto.setPassword(null);
+
+        Set<ConstraintViolation<UserMeDeleteDto>> violations = validator.validate(dto);
+
+        assertThat(violations).isEmpty();
+    }
+}


### PR DESCRIPTION
war einiges an rumprobiere erforderlich, Benutzer können nun gelöscht werden, das bedeutet:
- Nutzerbild wird vom System gelöscht
- Kontakte des Nutzers werden gelöscht, also die Einträge in der Datenbank
- seine für ihn hinterlegten Empfehlungen werden gelöscht, auch werden damit nicht mehr zugeordnete Empfehlungen gelöscht
- sollten von dem Nutzer erstellte Empfehlungen noch bei anderen Nutzern vorhanden sein, so wird dort der Ertseller auf null gesetzt !WICHTIG FÜRS FRONTEND!
@PaulRiisk @CovoxS7 @SaileSaile07 
Da jetzt die Recommendation auch null als Creator akzeptiert, müsst ihr nicht die Datenbank neu aufsetzen, sondern es reicht in der h2-Console:    ALTER TABLE recommendations ALTER COLUMN creator_id DROP NOT NULL
einzugeben
und im Frontend könnt ihr einfach eine Prüfung machen, ob der Creator in der Empfehlung null ist und dann als DisplayName irgendwas mit "Gelöschter Nutzer" oder so einbinden.
Ist einfacher als für sowas einen toten Nutzer mit vollständigem Profil in der Datenbank anzulegen
