### PR TITLE
Fix size limiting for recommendation description

### DIFF
--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/Recommendation.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/Recommendation.java
@@ -31,6 +31,7 @@ public class Recommendation {
     @Column(nullable = false)
     private String title;
 
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     private String imgPath;

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentService.java
@@ -36,6 +36,7 @@ public class RecommendationAssignmentService {
                 .recommendation(recommendation)
                 .receiver(receiver)
                 .sentAt(LocalDateTime.now())
+                .acceptedAt((Objects.equals(recommendation.getCreator().getId(), receiver.getId()) ? LocalDateTime.now() : null))
                 .recommendationAssignmentStatus(Objects.equals(recommendation.getCreator().getId(), receiver.getId()) ? RecommendationAssignmentStatus.ACCEPTED : RecommendationAssignmentStatus.SENT)
                 .build();
 

--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/dto/RecommendationRequestDto.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/dto/RecommendationRequestDto.java
@@ -17,7 +17,9 @@ public class RecommendationRequestDto {
     @NotBlank(message = "{recommendation.title.notblank}")
     private String title;
 
+    @Size(max = 2000, message = "{recommendation.description.max.value}")
     private String description;
+
     private String imgPath;
 
     @URL(message = "{recommendation.url.invalid}")

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -44,6 +44,7 @@ recommendation.assignment.error.user.not.allowed=Statusänderung nur für selbst
 recommendation.assignment.error.status.revert.to.sent=Statusänderung zu versendet nicht zulässig.
 recommendation.assignment.error.not.found=Zugewiesene Empfehlung nicht gefunden.
 recommendation.not.found=Empfehlung nicht gefunden.
+recommendation.description.max.value=Der Beschreibungstext darf nur maximal 2000 Zeichen lang sein.
 
 update.password.notblank=Profiländerungen müssen mit Passwort bestätigt werden.
 


### PR DESCRIPTION
Die Beschreibung der Empfehlung kann bis zu 2000 Zeichen lang sein