### PR TITLE
fix: self sent recommendations setting accepted date

### DIFF
--- a/src/main/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentService.java
+++ b/src/main/java/com/spaghetticodegang/trylater/recommendation/assignment/RecommendationAssignmentService.java
@@ -36,6 +36,7 @@ public class RecommendationAssignmentService {
                 .recommendation(recommendation)
                 .receiver(receiver)
                 .sentAt(LocalDateTime.now())
+                .acceptedAt((Objects.equals(recommendation.getCreator().getId(), receiver.getId()) ? LocalDateTime.now() : null))
                 .recommendationAssignmentStatus(Objects.equals(recommendation.getCreator().getId(), receiver.getId()) ? RecommendationAssignmentStatus.ACCEPTED : RecommendationAssignmentStatus.SENT)
                 .build();
 


### PR DESCRIPTION
Wenn sich ein Nutzer eine Empfehlung selbst schickt, wird jetzt auch das AcceptedAt gesetzt